### PR TITLE
Fix checksum comparison operation in godelw

### DIFF
--- a/resources/wrapper/godelw
+++ b/resources/wrapper/godelw
@@ -50,7 +50,7 @@ function verify_checksum {
     local file=$1
     local expected_checksum=$2
     local computed_checksum=$(compute_sha256 $file)
-    if [ ! $expected_checksum = $computed_checksum ]; then
+    if [ "$expected_checksum" != "$computed_checksum" ]; then
         echo "SHA-256 checksum for $file did not match expected value."
         echo "Expected: $expected_checksum"
         echo "Actual:   $computed_checksum"


### PR DESCRIPTION
Ensures that comparisons are done in a safe manner even if one
of the variables is empty.

Fixes #19