### PR TITLE
fix pre-commit hook so displays unformatted files

### DIFF
--- a/cmd/githooks/hooks.go
+++ b/cmd/githooks/hooks.go
@@ -30,16 +30,16 @@ var hooks = map[string]string{
 
 unformatted=$(./godelw format -l runAll $gofiles)
 exitCode=$?
-[[ $exitCode -ne 0 ]] && exit $exitCode
-[ -z "$unformatted" ] && exit 0
+[ "$exitCode" -eq "0" ] && exit 0
 
-# Unformatted files exist -- print and exit
-echo "Unformatted files exist -- run ./godelw format to format these files:"
-for file in $unformatted; do
-	echo "  $file"
-done
+if [ -n "$unformatted" ]; then
+  echo "Unformatted files exist -- run ./godelw format to format these files:"
+  for file in $unformatted; do
+    echo "  $file"
+  done
+fi
 
-exit 1
+exit $exitCode
 `,
 }
 


### PR DESCRIPTION
before, if unformatted files existed, pre-commit hook would silently exit non-zero with no explanation.

this commit fixes so that if `./godelw format` returns non-zero, so does the pre-commit, and if there are unformatted files, it logs those as well.

here's the new code with syntax highlighting:

```bash
gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
[ -z "$gofiles" ] && exit 0

unformatted=$(./godelw format -l runAll $gofiles)
exitCode=$?
[ "$exitCode" -eq "0" ] && exit 0

if [ -n "$unformatted" ]; then
  echo "Unformatted files exist -- run ./godelw format to format these files:"
  for file in $unformatted; do
    echo "  $file"
  done
fi

exit $exitCode
```