### PR TITLE
Add support for specifying release tag for okgo checks

### DIFF
--- a/apps/okgo/cmd/check.go
+++ b/apps/okgo/cmd/check.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/nmiyake/pkg/dirs"
@@ -34,12 +35,30 @@ import (
 	"github.com/palantir/godel/apps/okgo/params"
 )
 
-const packagesFlagName = "packages"
+const (
+	// releaseTagEnvVar the environment variable used to override the latest release tag that should be used in the
+	// default Go build context. See #72 for details.
+	releaseTagEnvVar = "OKGO_RELEASE_TAG"
+	packagesFlagName = "packages"
+)
 
 var packagesFlag = flag.StringSlice{
 	Name:     packagesFlagName,
 	Usage:    "Packages to check",
 	Optional: true,
+}
+
+func SetReleaseTagEnvVar(releaseTag string) error {
+	if releaseTag != "" {
+		if err := os.Setenv(releaseTagEnvVar, releaseTag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func GetReleaseTagEnvVar() string {
+	return os.Getenv(releaseTagEnvVar)
 }
 
 func RunAllCommand(supplier amalgomated.CmderSupplier) cli.Command {
@@ -107,6 +126,9 @@ func SingleCheckCommand(cmd amalgomated.Cmd, supplier amalgomated.CmderSupplier)
 			}
 			wd, err := dirs.GetwdEvalSymLinks()
 			if err != nil {
+				return err
+			}
+			if err := SetReleaseTagEnvVar(cfg.ReleaseTag); err != nil {
 				return err
 			}
 

--- a/apps/okgo/config/config.go
+++ b/apps/okgo/config/config.go
@@ -29,6 +29,14 @@ import (
 )
 
 type OKGo struct {
+	// ReleaseTag specifies the newest Go release build tag supported by the codebase being checked. If this value
+	// is not specified, it defaults to the Go release that was used to build the check tool. If the code being
+	// checked is known to use a version of Go that is earlier than the version of Go used to build the check tool
+	// and the codebase being checked contains build tags for the newer Go version, this value should be explicitly
+	// set. For example, if the check tool was compiled using Go 1.8 but the codebase being checked uses Go 1.7 and
+	// contains files that use the "// +build go1.8" build tag, then this should be set to "go1.7".
+	ReleaseTag string `yaml:"release-tag" json:"release-tag"`
+
 	// Checks specifies the configuration used by the checks. The key is the name of the check and the value is the
 	// custom configuration for that check.
 	Checks map[string]Checker `yaml:"checks" json:"checks"`
@@ -71,8 +79,9 @@ func (r *OKGo) ToParams() (params.OKGo, error) {
 		checks[cmd] = singleParam
 	}
 	return params.OKGo{
-		Checks:  checks,
-		Exclude: r.Exclude.Matcher(),
+		ReleaseTag: r.ReleaseTag,
+		Checks:     checks,
+		Exclude:    r.Exclude.Matcher(),
 	}, nil
 }
 

--- a/apps/okgo/config/example_test.go
+++ b/apps/okgo/config/example_test.go
@@ -22,6 +22,7 @@ import (
 
 func Example() {
 	yml := `
+release-tag: go1.7
 checks:
   errcheck:
     args:
@@ -39,5 +40,5 @@ checks:
 		panic(err)
 	}
 	fmt.Printf("%q", fmt.Sprintf("%+v", cfg))
-	// Output: "{Checks:map[errcheck:{Skip:false Args:[-ignore github.com/seelog:(Info|Warn|Error|Critical)f?] Filters:[{Type:message Value:\\w+}]}] Exclude:{Names:[] Paths:[]}}"
+	// Output: "{ReleaseTag:go1.7 Checks:map[errcheck:{Skip:false Args:[-ignore github.com/seelog:(Info|Warn|Error|Critical)f?] Filters:[{Type:message Value:\\w+}]}] Exclude:{Names:[] Paths:[]}}"
 }

--- a/apps/okgo/params/params.go
+++ b/apps/okgo/params/params.go
@@ -23,6 +23,9 @@ import (
 )
 
 type OKGo struct {
+	// ReleaseTag specifies the latest supported Go release tag. Empty if default should be used.
+	ReleaseTag string
+
 	// Checks specifies the configuration used by the checks. The key is the name of the check and the value is the
 	// custom configuration for that check.
 	Checks map[amalgomated.Cmd]Checker


### PR DESCRIPTION
Add a new "release-tag" configuration key that can be
used to specify the newest Go release tag that should
be used when checking Go files. Useful if the check
tool is used on a project that is being built with a
version of Go that is older than that used by the tool.

Fixes #72