### PR TITLE
Add project-version command

### DIFF
--- a/apps/distgo/app.go
+++ b/apps/distgo/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/palantir/godel/apps/distgo/cmd/build"
 	"github.com/palantir/godel/apps/distgo/cmd/dist"
 	"github.com/palantir/godel/apps/distgo/cmd/products"
+	"github.com/palantir/godel/apps/distgo/cmd/projectversion"
 	"github.com/palantir/godel/apps/distgo/cmd/publish"
 	"github.com/palantir/godel/apps/distgo/cmd/run"
 )
@@ -32,6 +33,7 @@ func App() *cli.App {
 	app.Name = "distgo"
 	app.Usage = "Build, run, test and publish products in a Go project"
 	app.Subcommands = []cli.Command{
+		projectversion.Command(),
 		products.Command(),
 		artifacts.Command(),
 		build.Command(),

--- a/apps/distgo/cmd/projectversion/cmd.go
+++ b/apps/distgo/cmd/projectversion/cmd.go
@@ -1,0 +1,34 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projectversion
+
+import (
+	"github.com/nmiyake/pkg/dirs"
+	"github.com/palantir/pkg/cli"
+)
+
+func Command() cli.Command {
+	return cli.Command{
+		Name:  "project-version",
+		Usage: "Prints the version of the project (based on Git information)",
+		Action: func(ctx cli.Context) error {
+			wd, err := dirs.GetwdEvalSymLinks()
+			if err != nil {
+				return err
+			}
+			return Print(wd, ctx.App.Stdout)
+		},
+	}
+}

--- a/apps/distgo/cmd/projectversion/projectversion.go
+++ b/apps/distgo/cmd/projectversion/projectversion.go
@@ -1,0 +1,32 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package projectversion
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/palantir/godel/apps/distgo/pkg/git"
+)
+
+func Print(wd string, stdout io.Writer) error {
+	projectInfo, err := git.NewProjectInfo(wd)
+	version := "unspecified"
+	if err == nil {
+		version = projectInfo.Version
+	}
+	fmt.Fprintln(stdout, version)
+	return nil
+}

--- a/cmd/clicmds/cfgcli.go
+++ b/cmd/clicmds/cfgcli.go
@@ -135,6 +135,13 @@ var (
 			pathToCfg:      []string{"dist.yml"},
 		},
 		{
+			name:           "project-version",
+			app:            distgoCreator,
+			decorator:      distgoDecorator,
+			subcommandPath: []string{"project-version"},
+			pathToCfg:      []string{"dist.yml"},
+		},
+		{
 			name:           "build",
 			app:            distgoCreator,
 			decorator:      distgoDecorator,

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -77,6 +77,21 @@ func TestVersion(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("godel version %v\n", version), string(output))
 }
 
+func TestProjectVersion(t *testing.T) {
+	tmpDir, cleanup, err := dirs.TempDir("", "")
+	defer cleanup()
+	require.NoError(t, err)
+
+	gittest.InitGitDir(t, tmpDir)
+	gittest.CreateGitTag(t, tmpDir, "testTag")
+	err = ioutil.WriteFile(path.Join(tmpDir, "random.txt"), []byte(""), 0644)
+	require.NoError(t, err)
+
+	testProjectDir := setUpGödelTestAndDownload(t, tmpDir, gödelTGZ, version)
+	output := execCommand(t, testProjectDir, "./godelw", "project-version")
+	assert.Equal(t, "testTag.dirty\n", string(output))
+}
+
 func TestGitHooksSuccess(t *testing.T) {
 	// create project directory in temporary location so primary project's repository is not modified by test
 	tmp, cleanup, err := dirs.TempDir("", "")


### PR DESCRIPTION
* Add "project-version" command to distgo that prints the version
  used for build/dist commands.
* Add "project-version" command to gödel that calls distgo command

Fixes #92

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel/93)
<!-- Reviewable:end -->
