### PR TITLE
Update gunit tags to use NamesPathsWithExcludeCfg

### DIFF
--- a/apps/gunit/config/config.go
+++ b/apps/gunit/config/config.go
@@ -26,10 +26,10 @@ import (
 )
 
 type GUnit struct {
-	// Tags group tests into different sets. The key is the name of the tag and the value is a matcher.NamesPathsCfg
-	// that specifies the rules for matching the tests that are part of the tag. Any test that matches the provided
-	// matcher is considered part of the tag.
-	Tags map[string]matcher.NamesPathsCfg `yaml:"tags" json:"tags"`
+	// Tags group tests into different sets. The key is the name of the tag and the value is a
+	// matcher.NamesPathsWithExcludeCfg that specifies the rules for matching the tests that are part of the tag.
+	// Any test that matches the provided matcher is considered part of the tag.
+	Tags map[string]matcher.NamesPathsWithExcludeCfg `yaml:"tags" json:"tags"`
 
 	// Exclude specifies the files that should be excluded from tests.
 	Exclude matcher.NamesPathsCfg `yaml:"exclude" json:"exclude"`

--- a/apps/gunit/config/config_test.go
+++ b/apps/gunit/config/config_test.go
@@ -41,6 +41,11 @@ func TestLoadConfig(t *testing.T) {
 			      - "integration_tests"
 			    paths:
 			      - "test"
+			    exclude:
+			      names:
+			        - "ignore"
+			      paths:
+			        - "test/foo"
 			exclude:
 			  names:
 			    - ".*test"
@@ -50,10 +55,16 @@ func TestLoadConfig(t *testing.T) {
 			`,
 			json: `{"exclude":{"names":["gunit"],"paths":["generated_src"]}}`,
 			want: config.GUnit{
-				Tags: map[string]matcher.NamesPathsCfg{
+				Tags: map[string]matcher.NamesPathsWithExcludeCfg{
 					"integration": {
-						Names: []string{`integration_tests`},
-						Paths: []string{`test`},
+						NamesPathsCfg: matcher.NamesPathsCfg{
+							Names: []string{`integration_tests`},
+							Paths: []string{`test`},
+						},
+						Exclude: matcher.NamesPathsCfg{
+							Names: []string{`ignore`},
+							Paths: []string{`test/foo`},
+						},
 					},
 				},
 				Exclude: matcher.NamesPathsCfg{
@@ -76,12 +87,16 @@ func TestLoadConfig(t *testing.T) {
 			      - "test"
 			`,
 			want: config.GUnit{
-				Tags: map[string]matcher.NamesPathsCfg{
+				Tags: map[string]matcher.NamesPathsWithExcludeCfg{
 					"integration": {
-						Names: []string{`integration_tests`},
+						NamesPathsCfg: matcher.NamesPathsCfg{
+							Names: []string{`integration_tests`},
+						},
 					},
 					"mixedCasing": {
-						Paths: []string{`test`},
+						NamesPathsCfg: matcher.NamesPathsCfg{
+							Paths: []string{`test`},
+						},
 					},
 				},
 			},

--- a/apps/gunit/config/example_test.go
+++ b/apps/gunit/config/example_test.go
@@ -28,11 +28,16 @@ tags:
       - "integration_tests"
     paths:
       - "test"
+    exclude:
+      names:
+        - "ignore"
+      paths:
+        - "test/exclude"
 `
 	cfg, err := config.LoadRawConfig(yml, "")
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("%q", fmt.Sprintf("%+v", cfg))
-	// Output: "{Tags:map[integration:{Names:[integration_tests] Paths:[test]}] Exclude:{Names:[] Paths:[]}}"
+	// Output: "{Tags:map[integration:{NamesPathsCfg:{Names:[integration_tests] Paths:[test]} Exclude:{Names:[ignore] Paths:[test/exclude]}}] Exclude:{Names:[] Paths:[]}}"
 }

--- a/vendor/github.com/palantir/pkg/matcher/config.go
+++ b/vendor/github.com/palantir/pkg/matcher/config.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+// Copyright 2016 Palantir Technologies. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -27,4 +27,18 @@ func (c *NamesPathsCfg) Empty() bool {
 // names or paths in the configuration.
 func (c *NamesPathsCfg) Matcher() Matcher {
 	return Any(Name(c.Names...), Path(c.Paths...))
+}
+
+// NamesPathsWithExcludeCfg is a configuration object that defines a matcher and a set of criteria that should be used
+// to exclude matches. The returned Matcher will match any name or path specified in the configuration provided that the
+// matched path does not match the matcher produced by the "Exclude" configuration.
+type NamesPathsWithExcludeCfg struct {
+	NamesPathsCfg `yaml:",inline"`
+	Exclude       NamesPathsCfg `yaml:"exclude" json:"exclude"`
+}
+
+// Matcher returns a Matcher constructed from the configuration. The Matcher returns true if it matches any of the
+// names or paths in the configuration and does not match any of the criteria specified in the "Exclude" configuration.
+func (c *NamesPathsWithExcludeCfg) Matcher() Matcher {
+	return All(c.NamesPathsCfg.Matcher(), Not(c.Exclude.Matcher()))
 }

--- a/vendor/github.com/palantir/pkg/matcher/files.go
+++ b/vendor/github.com/palantir/pkg/matcher/files.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+// Copyright 2016 Palantir Technologies. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/github.com/palantir/pkg/matcher/matchers.go
+++ b/vendor/github.com/palantir/pkg/matcher/matchers.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+// Copyright 2016 Palantir Technologies. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -341,10 +341,10 @@
 			"revisionTime": "2016-12-02T17:17:08Z"
 		},
 		{
-			"checksumSHA1": "MhrjempJy/hQiqcj1axZp/oox9Q=",
+			"checksumSHA1": "rBe6S08Qg9PJd56jlY5knLgUQLk=",
 			"path": "github.com/palantir/pkg/matcher",
-			"revision": "c60ea2d471b77fae0cd4219bd329bd7e0e01d5b8",
-			"revisionTime": "2016-12-02T17:17:08Z"
+			"revision": "5d8e3ae75f4c1da9363692b04fcb4334bf09b82a",
+			"revisionTime": "2017-04-06T01:49:46Z"
 		},
 		{
 			"checksumSHA1": "wFdDjAqsTus/qC39RSSB7liU124=",


### PR DESCRIPTION
Allows tags to exclude specific files or paths from matching.