### PR TITLE
Add OSArchDist as a new dist type

### DIFF
--- a/apps/distgo/cmd/dist/dist.go
+++ b/apps/distgo/cmd/dist/dist.go
@@ -141,6 +141,10 @@ func Run(buildSpecWithDeps params.ProductBuildSpecWithDeps, stdout io.Writer) er
 			if packager, err = binDist(buildSpecWithDeps, currDistCfg, outputProductDir); err != nil {
 				return err
 			}
+		case params.OSArchBinDistType:
+			if packager, err = osArchBinDist(buildSpecWithDeps, currDistCfg, outputProductDir); err != nil {
+				return err
+			}
 		case params.RPMDistType:
 			if packager, err = rpmDist(buildSpecWithDeps, currDistCfg, outputProductDir, stdout); err != nil {
 				return err
@@ -166,9 +170,9 @@ func Run(buildSpecWithDeps params.ProductBuildSpecWithDeps, stdout io.Writer) er
 	return nil
 }
 
-func tgzPackager(buildSpec params.ProductBuildSpec, distCfg params.Dist, outputProductDir string) packager {
+func tgzPackager(buildSpec params.ProductBuildSpec, distCfg params.Dist, pathsToPackage ...string) packager {
 	return packager(func() error {
-		return archiver.TarGz(ArtifactPath(buildSpec, distCfg), []string{outputProductDir})
+		return archiver.TarGz(ArtifactPath(buildSpec, distCfg), pathsToPackage)
 	})
 }
 
@@ -215,6 +219,9 @@ func ArtifactPath(buildSpec params.ProductBuildSpec, distCfg params.Dist) string
 		fileName = slsspec.New().RootDirName(values) + ".sls.tgz"
 	case params.BinDistType:
 		fileName = fmt.Sprintf("%v-%v.tgz", buildSpec.ProductName, buildSpec.ProductVersion)
+	case params.OSArchBinDistType:
+		osArchDistInfo := distCfg.Info.(*params.OSArchBinDistInfo)
+		fileName = fmt.Sprintf("%s-%s-%s.tgz", buildSpec.ProductName, buildSpec.ProductVersion, osArchDistInfo.OSArch.String())
 	case params.RPMDistType:
 		release := defaultRPMRelease
 		if rpmDistInfo, ok := distCfg.Info.(*params.RPMDistInfo); ok && rpmDistInfo.Release != "" {

--- a/apps/distgo/cmd/dist/osarchbindist.go
+++ b/apps/distgo/cmd/dist/osarchbindist.go
@@ -1,0 +1,105 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dist
+
+import (
+	"path"
+	"sort"
+
+	"github.com/pkg/errors"
+	"github.com/termie/go-shutil"
+
+	"github.com/palantir/godel/apps/distgo/cmd/build"
+	"github.com/palantir/godel/apps/distgo/params"
+	"github.com/palantir/godel/apps/distgo/pkg/osarch"
+)
+
+func osArchBinDist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.Dist, outputProductDir string) (Packager, error) {
+	buildSpec := buildSpecWithDeps.Spec
+	osArchBinDistInfo, ok := distCfg.Info.(*params.OSArchBinDistInfo)
+	if !ok {
+		osArchBinDistInfo = &params.OSArchBinDistInfo{}
+		distCfg.Info = osArchBinDistInfo
+	}
+
+	osArch := osArchBinDistInfo.OSArch
+	if err := verifyDistTargetSupported(osArch, buildSpecWithDeps); err != nil {
+		return nil, err
+	}
+
+	var outputPaths []string
+	// copy executable for current product
+	dst, err := copyArtifactForOSArch(outputProductDir, buildSpec, osArch)
+	if err != nil {
+		return nil, err
+	}
+	outputPaths = append(outputPaths, dst)
+
+	// copy executables for dependent products
+	for _, currDepSpec := range buildSpecWithDeps.Deps {
+		dst, err := copyArtifactForOSArch(outputProductDir, currDepSpec, osArch)
+		if err != nil {
+			return nil, err
+		}
+		outputPaths = append(outputPaths, dst)
+	}
+
+	return tgzPackager(buildSpec, distCfg, outputPaths...), nil
+}
+
+func verifyDistTargetSupported(osArch osarch.OSArch, buildSpecWithDeps params.ProductBuildSpecWithDeps) error {
+	spec := buildSpecWithDeps.Spec
+	if !osArchInBuildSpec(osArch, spec) {
+		return errors.Errorf("The OS/Arch specified for the distribution of a product must be specified as a build target for the product, "+
+			"but product %s does not specify %s as one of its build targets. Current build targets: %v", spec.ProductName, osArch, spec.Build.OSArchs)
+	}
+
+	var keys []string
+	for k := range buildSpecWithDeps.Deps {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, currKey := range keys {
+		currSpec := buildSpecWithDeps.Deps[currKey]
+		if !osArchInBuildSpec(osArch, spec) {
+			return errors.Errorf("The OS/Arch specified for the distribution of a product must be specified as a build target for the product, "+
+				"but product %s (which is a dependent product of %s) does not specify %s as one of its build targets. Current build targets: %v", currSpec.ProductName, buildSpecWithDeps.Spec.ProductName, osArch, currSpec.Build.OSArchs)
+		}
+	}
+	return nil
+}
+
+func osArchInBuildSpec(osArch osarch.OSArch, spec params.ProductBuildSpec) bool {
+	found := false
+	for _, currBuildOSArch := range spec.Build.OSArchs {
+		if currBuildOSArch == osArch {
+			found = true
+			break
+		}
+	}
+	return found
+}
+
+func copyArtifactForOSArch(outputProductDir string, buildSpec params.ProductBuildSpec, osArch osarch.OSArch) (string, error) {
+	artifactPath, ok := build.ArtifactPaths(buildSpec)[osArch]
+	if !ok {
+		return "", errors.Errorf("no build artifacts exist for %s", osArch)
+	}
+	dst := path.Join(outputProductDir, build.ExecutableName(buildSpec.ProductName, osArch.OS))
+	if _, err := shutil.Copy(artifactPath, dst, false); err != nil {
+		return "", errors.Wrapf(err, "failed to copy build artifact from %s to %s", artifactPath, dst)
+	}
+	return dst, nil
+}

--- a/apps/distgo/params/dist.go
+++ b/apps/distgo/params/dist.go
@@ -16,6 +16,8 @@ package params
 
 import (
 	"github.com/palantir/pkg/matcher"
+
+	"github.com/palantir/godel/apps/distgo/pkg/osarch"
 )
 
 type Dist struct {
@@ -60,13 +62,23 @@ type Dist struct {
 type DistInfoType string
 
 const (
-	SLSDistType DistInfoType = "sls" // distribution that uses the Standard Layout Specification
-	BinDistType DistInfoType = "bin" // distribution that includes all of the binaries for a product
-	RPMDistType DistInfoType = "rpm" // RPM distribution
+	SLSDistType       DistInfoType = "sls"         // distribution that uses the Standard Layout Specification
+	BinDistType       DistInfoType = "bin"         // distribution that includes all of the binaries for a product
+	RPMDistType       DistInfoType = "rpm"         // RPM distribution
+	OSArchBinDistType DistInfoType = "os-arch-bin" // distribution that consists of the binaries for a specific OS/Architecture
 )
 
 type DistInfo interface {
 	Type() DistInfoType
+}
+
+type OSArchBinDistInfo struct {
+	// OSArch specifies the OS/architecture combination for this distribution.
+	OSArch osarch.OSArch
+}
+
+func (i *OSArchBinDistInfo) Type() DistInfoType {
+	return OSArchBinDistType
 }
 
 type BinDistInfo struct {


### PR DESCRIPTION
Adds a new distribution type for a tgz that creates a TGZ that
contains the executable for a specified OS/Arch.

Fixes #98