### PR TITLE
Refactor dist types to centralize logic

### DIFF
--- a/apps/distgo/cmd/artifacts/artifacts.go
+++ b/apps/distgo/cmd/artifacts/artifacts.go
@@ -31,7 +31,7 @@ func DistArtifacts(buildSpecsWithDeps []params.ProductBuildSpecWithDeps, absPath
 		distTypeToPathMap := newOrderedStringMap()
 
 		for _, currDistCfg := range spec.Dist {
-			distTypeToPathMap.Put(string(currDistCfg.Info.Type()), dist.ArtifactPath(spec, currDistCfg))
+			distTypeToPathMap.Put(string(currDistCfg.Info.Type()), dist.FullArtifactPath(currDistCfg.Info.Type(), spec, currDistCfg))
 		}
 		return buildSpecWithPaths{spec: &spec, paths: distTypeToPathMap}
 	}, absPath)

--- a/apps/distgo/cmd/dist/bindist.go
+++ b/apps/distgo/cmd/dist/bindist.go
@@ -16,6 +16,8 @@ package dist
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"path"
 	"text/template"
@@ -61,7 +63,13 @@ fi
 $CMD "$@"
 `
 
-func binDist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.Dist, outputProductDir string) (Packager, error) {
+type binDistStruct struct{}
+
+func (b *binDistStruct) ArtifactPathInOutputDir(buildSpec params.ProductBuildSpec, distCfg params.Dist) string {
+	return fmt.Sprintf("%v-%v.tgz", buildSpec.ProductName, buildSpec.ProductVersion)
+}
+
+func (b *binDistStruct) Dist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.Dist, outputProductDir string, spec specdir.LayoutSpec, values specdir.TemplateValues, stdout io.Writer) (Packager, error) {
 	buildSpec := buildSpecWithDeps.Spec
 	binDistInfo, ok := distCfg.Info.(*params.BinDistInfo)
 	if !ok {
@@ -102,4 +110,8 @@ func binDist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.D
 	}
 
 	return tgzPackager(buildSpec, distCfg, outputProductDir), nil
+}
+
+func (b *binDistStruct) DistPackageType() string {
+	return "tgz"
 }

--- a/apps/distgo/cmd/dist/osarchbindist.go
+++ b/apps/distgo/cmd/dist/osarchbindist.go
@@ -15,9 +15,12 @@
 package dist
 
 import (
+	"fmt"
+	"io"
 	"path"
 	"sort"
 
+	"github.com/palantir/pkg/specdir"
 	"github.com/pkg/errors"
 	"github.com/termie/go-shutil"
 
@@ -26,7 +29,14 @@ import (
 	"github.com/palantir/godel/apps/distgo/pkg/osarch"
 )
 
-func osArchBinDist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.Dist, outputProductDir string) (Packager, error) {
+type osArchBinDistStruct struct{}
+
+func (o *osArchBinDistStruct) ArtifactPathInOutputDir(buildSpec params.ProductBuildSpec, distCfg params.Dist) string {
+	osArchDistInfo := distCfg.Info.(*params.OSArchBinDistInfo)
+	return fmt.Sprintf("%s-%s-%s.tgz", buildSpec.ProductName, buildSpec.ProductVersion, osArchDistInfo.OSArch.String())
+}
+
+func (o *osArchBinDistStruct) Dist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.Dist, outputProductDir string, spec specdir.LayoutSpec, values specdir.TemplateValues, stdout io.Writer) (Packager, error) {
 	buildSpec := buildSpecWithDeps.Spec
 	osArchBinDistInfo, ok := distCfg.Info.(*params.OSArchBinDistInfo)
 	if !ok {
@@ -57,6 +67,10 @@ func osArchBinDist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg pa
 	}
 
 	return tgzPackager(buildSpec, distCfg, outputPaths...), nil
+}
+
+func (o *osArchBinDistStruct) DistPackageType() string {
+	return "tgz"
 }
 
 func verifyDistTargetSupported(osArch osarch.OSArch, buildSpecWithDeps params.ProductBuildSpecWithDeps) error {

--- a/apps/distgo/cmd/dist/slsdist.go
+++ b/apps/distgo/cmd/dist/slsdist.go
@@ -16,6 +16,7 @@ package dist
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"path"
 	"strings"
@@ -187,7 +188,14 @@ reload){{if .Dist.Reloadable}}
 esac
 `
 
-func slsDist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.Dist, outputProductDir string, spec specdir.LayoutSpec, values specdir.TemplateValues) (Packager, error) {
+type slsDistStruct struct{}
+
+func (s *slsDistStruct) ArtifactPathInOutputDir(buildSpec params.ProductBuildSpec, distCfg params.Dist) string {
+	values := slsspec.TemplateValues(buildSpec.ProductName, buildSpec.ProductVersion)
+	return slsspec.New().RootDirName(values) + ".sls.tgz"
+}
+
+func (s *slsDistStruct) Dist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.Dist, outputProductDir string, spec specdir.LayoutSpec, values specdir.TemplateValues, stdout io.Writer) (Packager, error) {
 	buildSpec := buildSpecWithDeps.Spec
 	outputSLSDir := path.Join(buildSpec.ProjectDir, distCfg.OutputDir, spec.RootDirName(values))
 
@@ -233,6 +241,10 @@ func slsDist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.D
 		}
 		return nil
 	}), nil
+}
+
+func (s *slsDistStruct) DistPackageType() string {
+	return "sls.tgz"
 }
 
 func writeSLSManifest(buildSpec params.ProductBuildSpec, distCfg params.Dist, slsDistInfo params.SLSDistInfo, specDir specdir.SpecDir) error {

--- a/apps/distgo/cmd/dist/types.go
+++ b/apps/distgo/cmd/dist/types.go
@@ -1,0 +1,51 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dist
+
+import (
+	"fmt"
+	"io"
+	"path"
+
+	"github.com/palantir/pkg/specdir"
+
+	"github.com/palantir/godel/apps/distgo/params"
+)
+
+type Dister interface {
+	ArtifactPathInOutputDir(buildSpec params.ProductBuildSpec, distCfg params.Dist) string
+	Dist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.Dist, outputProductDir string, spec specdir.LayoutSpec, values specdir.TemplateValues, stdout io.Writer) (Packager, error)
+	DistPackageType() string
+}
+
+func DisterForType(typ params.DistInfoType) Dister {
+	dister, ok := distInfoTypeDataMap[typ]
+	if !ok {
+		panic(fmt.Sprintf("unrecognized type: %v", typ))
+	}
+	return dister
+}
+
+func FullArtifactPath(distType params.DistInfoType, buildSpec params.ProductBuildSpec, distCfg params.Dist) string {
+	dister := DisterForType(distType)
+	return path.Join(buildSpec.ProjectDir, distCfg.OutputDir, dister.ArtifactPathInOutputDir(buildSpec, distCfg))
+}
+
+var distInfoTypeDataMap = map[params.DistInfoType]Dister{
+	params.SLSDistType:       &slsDistStruct{},
+	params.BinDistType:       &binDistStruct{},
+	params.OSArchBinDistType: &osArchBinDistStruct{},
+	params.RPMDistType:       &rpmDistStruct{},
+}

--- a/apps/distgo/cmd/docker/build.go
+++ b/apps/distgo/cmd/docker/build.go
@@ -115,7 +115,7 @@ func buildImage(image params.DockerImage, buildSpecsWithDeps params.ProductBuild
 					depType, depProduct, buildSpecsWithDeps.Spec.ProductName)
 			}
 			distCfg := distsMap[string(depType)]
-			artifactLocation := dist.ArtifactPath(depSpec, distCfg)
+			artifactLocation := dist.FullArtifactPath(distCfg.Info.Type(), depSpec, distCfg)
 			if targetFile == "" {
 				targetFile = path.Base(artifactLocation)
 			}

--- a/apps/distgo/cmd/publish/publish.go
+++ b/apps/distgo/cmd/publish/publish.go
@@ -66,7 +66,7 @@ func Run(buildSpecWithDeps params.ProductBuildSpecWithDeps, publisher Publisher,
 	buildSpec := buildSpecWithDeps.Spec
 	for _, currDistCfg := range buildSpec.Dist {
 		// verify that distribution to publish exists
-		artifactPath := dist.ArtifactPath(buildSpec, currDistCfg)
+		artifactPath := dist.FullArtifactPath(currDistCfg.Info.Type(), buildSpec, currDistCfg)
 		if _, err := os.Stat(artifactPath); os.IsNotExist(err) {
 			return errors.Errorf("distribution for %v does not exist at %v", buildSpec.ProductName, artifactPath)
 		}
@@ -95,7 +95,7 @@ func DistsNotBuilt(buildSpecWithDeps []params.ProductBuildSpecWithDeps) []params
 	for _, currBuildSpecWithDeps := range buildSpecWithDeps {
 		currBuildSpec := currBuildSpecWithDeps.Spec
 		for _, currDistCfg := range currBuildSpec.Dist {
-			artifactPath := dist.ArtifactPath(currBuildSpec, currDistCfg)
+			artifactPath := dist.FullArtifactPath(currDistCfg.Info.Type(), currBuildSpec, currDistCfg)
 			if _, err := os.Stat(artifactPath); os.IsNotExist(err) {
 				distsNotBuilt = append(distsNotBuilt, currBuildSpecWithDeps)
 			}
@@ -137,7 +137,7 @@ func productPath(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg para
 	return ProductPaths{
 		productPath:  path.Join(path.Join(strings.Split(distCfg.Publish.GroupID, ".")...), buildSpec.ProductName, buildSpec.ProductVersion),
 		pomFilePath:  pomFilePath,
-		artifactPath: dist.ArtifactPath(buildSpec, distCfg),
+		artifactPath: dist.FullArtifactPath(distCfg.Info.Type(), buildSpec, distCfg),
 	}, nil
 }
 


### PR DESCRIPTION
Use a more specific typing system to make it easier to add new
dist types and to keep track of the logic shared between different
aspects of a dist type.