### PR TITLE
Add support for generating multiple artifacts per dist

### DIFF
--- a/apps/distgo/cmd/artifacts/cmd.go
+++ b/apps/distgo/cmd/artifacts/cmd.go
@@ -84,11 +84,12 @@ func artifactsCommand(name, usage string, action artifactsAction) cli.Command {
 			for _, spec := range specs {
 				if v, ok := artifacts[spec.Spec.ProductName]; ok {
 					for _, k := range v.Keys() {
-						ctx.Println(v.Get(k))
+						for _, currPath := range v.Get(k) {
+							ctx.Println(currPath)
+						}
 					}
 				}
 			}
-
 			return nil
 		},
 	}
@@ -102,9 +103,9 @@ func buildArtifactsCommand(name, usage string) cli.Command {
 	return buildCmd
 }
 
-type artifactsAction func(ctx cli.Context, specs []params.ProductBuildSpecWithDeps, absPath bool) (map[string]OrderedStringMap, error)
+type artifactsAction func(ctx cli.Context, specs []params.ProductBuildSpecWithDeps, absPath bool) (map[string]OrderedStringSliceMap, error)
 
-func buildArtifactsAction(ctx cli.Context, specs []params.ProductBuildSpecWithDeps, absPath bool) (map[string]OrderedStringMap, error) {
+func buildArtifactsAction(ctx cli.Context, specs []params.ProductBuildSpecWithDeps, absPath bool) (map[string]OrderedStringSliceMap, error) {
 	osArchsFilter, err := cmd.NewOSArchFilter(ctx.String(cmd.OSArchFlagName))
 	if err != nil {
 		return nil, err
@@ -116,6 +117,6 @@ func buildArtifactsAction(ctx cli.Context, specs []params.ProductBuildSpecWithDe
 	})
 }
 
-func distArtifactsAction(ctx cli.Context, specs []params.ProductBuildSpecWithDeps, absPath bool) (map[string]OrderedStringMap, error) {
+func distArtifactsAction(ctx cli.Context, specs []params.ProductBuildSpecWithDeps, absPath bool) (map[string]OrderedStringSliceMap, error) {
 	return DistArtifacts(specs, absPath)
 }

--- a/apps/distgo/cmd/dist/bindist.go
+++ b/apps/distgo/cmd/dist/bindist.go
@@ -65,8 +65,12 @@ $CMD "$@"
 
 type binDister params.BinDistInfo
 
-func (b *binDister) ArtifactPathInOutputDir(buildSpec params.ProductBuildSpec) string {
-	return fmt.Sprintf("%v-%v.tgz", buildSpec.ProductName, buildSpec.ProductVersion)
+func (b *binDister) NumArtifacts() int {
+	return 1
+}
+
+func (b *binDister) ArtifactPathsInOutputDir(buildSpec params.ProductBuildSpec) []string {
+	return []string{fmt.Sprintf("%v-%v.tgz", buildSpec.ProductName, buildSpec.ProductVersion)}
 }
 
 func (b *binDister) Dist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.Dist, outputProductDir string, spec specdir.LayoutSpec, values specdir.TemplateValues, stdout io.Writer) (Packager, error) {
@@ -103,7 +107,9 @@ func (b *binDister) Dist(buildSpecWithDeps params.ProductBuildSpecWithDeps, dist
 		}
 	}
 
-	return tgzPackager(buildSpec, distCfg, outputProductDir), nil
+	// known to only have 1 output path
+	dstPath := FullArtifactsPaths(b, buildSpec, distCfg)[0]
+	return singlePathTGZPackager(dstPath, outputProductDir), nil
 }
 
 func (b *binDister) DistPackageType() string {

--- a/apps/distgo/cmd/dist/dist_test.go
+++ b/apps/distgo/cmd/dist/dist_test.go
@@ -1048,7 +1048,9 @@ daemon: true
 						},
 						Dist: []params.Dist{{
 							Info: &params.OSArchsBinDistInfo{
-								OSArch: osarch.Current(),
+								OSArchs: []osarch.OSArch{
+									osarch.Current(),
+								},
 							},
 						}},
 					},
@@ -1093,9 +1095,11 @@ daemon: true
 						},
 						Dist: []params.Dist{{
 							Info: &params.OSArchsBinDistInfo{
-								OSArch: osarch.OSArch{
-									OS:   "darwin",
-									Arch: "amd64",
+								OSArchs: []osarch.OSArch{
+									{
+										OS:   "darwin",
+										Arch: "amd64",
+									},
 								},
 							},
 						}},

--- a/apps/distgo/cmd/dist/dister.go
+++ b/apps/distgo/cmd/dist/dister.go
@@ -25,7 +25,8 @@ import (
 )
 
 type Dister interface {
-	ArtifactPathInOutputDir(buildSpec params.ProductBuildSpec) string
+	NumArtifacts() int
+	ArtifactPathsInOutputDir(buildSpec params.ProductBuildSpec) []string
 	Dist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.Dist, outputProductDir string, spec specdir.LayoutSpec, values specdir.TemplateValues, stdout io.Writer) (Packager, error)
 	DistPackageType() string
 }
@@ -45,6 +46,10 @@ func ToDister(info params.DistInfo) Dister {
 	}
 }
 
-func FullArtifactPath(dister Dister, buildSpec params.ProductBuildSpec, distCfg params.Dist) string {
-	return path.Join(buildSpec.ProjectDir, distCfg.OutputDir, dister.ArtifactPathInOutputDir(buildSpec))
+func FullArtifactsPaths(dister Dister, buildSpec params.ProductBuildSpec, distCfg params.Dist) []string {
+	var outPaths []string
+	for _, currPath := range dister.ArtifactPathsInOutputDir(buildSpec) {
+		outPaths = append(outPaths, path.Join(buildSpec.ProjectDir, distCfg.OutputDir, currPath))
+	}
+	return outPaths
 }

--- a/apps/distgo/cmd/dist/rpmdist.go
+++ b/apps/distgo/cmd/dist/rpmdist.go
@@ -32,12 +32,16 @@ const defaultRPMRelease = "1"
 
 type rpmDister params.RPMDistInfo
 
-func (r *rpmDister) ArtifactPathInOutputDir(buildSpec params.ProductBuildSpec) string {
+func (r *rpmDister) NumArtifacts() int {
+	return 1
+}
+
+func (r *rpmDister) ArtifactPathsInOutputDir(buildSpec params.ProductBuildSpec) []string {
 	release := defaultRPMRelease
 	if r.Release != "" {
 		release = r.Release
 	}
-	return fmt.Sprintf("%v-%v-%v.x86_64.rpm", buildSpec.ProductName, buildSpec.ProductVersion, release)
+	return []string{fmt.Sprintf("%v-%v-%v.x86_64.rpm", buildSpec.ProductName, buildSpec.ProductVersion, release)}
 }
 
 func (r *rpmDister) Dist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.Dist, outputProductDir string, spec specdir.LayoutSpec, values specdir.TemplateValues, stdout io.Writer) (p Packager, rErr error) {
@@ -77,7 +81,7 @@ func (r *rpmDister) Dist(buildSpecWithDeps params.ProductBuildSpecWithDeps, dist
 		"-n", buildSpec.ProductName,
 		"-v", buildSpec.ProductVersion,
 		"--iteration", release,
-		"-p", FullArtifactPath(ToDister(distCfg.Info), buildSpec, distCfg),
+		"-p", FullArtifactsPaths(r, buildSpec, distCfg)[0],
 		"-s", "dir",
 		"-C", outputProductDir,
 		"--rpm-os", "linux",

--- a/apps/distgo/cmd/dist/slsdist.go
+++ b/apps/distgo/cmd/dist/slsdist.go
@@ -190,9 +190,13 @@ esac
 
 type slsDister params.SLSDistInfo
 
-func (s *slsDister) ArtifactPathInOutputDir(buildSpec params.ProductBuildSpec) string {
+func (s *slsDister) NumArtifacts() int {
+	return 1
+}
+
+func (s *slsDister) ArtifactPathsInOutputDir(buildSpec params.ProductBuildSpec) []string {
 	values := slsspec.TemplateValues(buildSpec.ProductName, buildSpec.ProductVersion)
-	return slsspec.New().RootDirName(values) + ".sls.tgz"
+	return []string{slsspec.New().RootDirName(values) + ".sls.tgz"}
 }
 
 func (s *slsDister) Dist(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg params.Dist, outputProductDir string, spec specdir.LayoutSpec, values specdir.TemplateValues, stdout io.Writer) (Packager, error) {
@@ -228,7 +232,9 @@ func (s *slsDister) Dist(buildSpecWithDeps params.ProductBuildSpecWithDeps, dist
 		if err := slsspec.Validate(outputProductDir, values, s.YMLValidationExclude); err != nil {
 			return errors.Wrapf(err, "distribution directory failed SLS validation")
 		}
-		if err := tgzPackager(buildSpec, distCfg, outputProductDir).Package(); err != nil {
+
+		dstArtifactPath := FullArtifactsPaths(s, buildSpec, distCfg)[0]
+		if err := singlePathTGZPackager(dstArtifactPath, outputProductDir).Package(); err != nil {
 			return err
 		}
 		return nil

--- a/apps/distgo/cmd/docker/build.go
+++ b/apps/distgo/cmd/docker/build.go
@@ -115,19 +115,21 @@ func buildImage(image params.DockerImage, buildSpecsWithDeps params.ProductBuild
 					depType, depProduct, buildSpecsWithDeps.Spec.ProductName)
 			}
 			distCfg := distsMap[string(depType)]
-			artifactLocation := dist.FullArtifactPath(dist.ToDister(distCfg.Info), depSpec, distCfg)
-			if targetFile == "" {
-				targetFile = path.Base(artifactLocation)
-			}
-			target := path.Join(contextDir, targetFile)
-			if _, err := os.Stat(target); err == nil {
-				// ensure the target does not exists before creating a new one
-				if err := os.Remove(target); err != nil {
+
+			for _, artifactLocation := range dist.FullArtifactsPaths(dist.ToDister(distCfg.Info), depSpec, distCfg) {
+				if targetFile == "" {
+					targetFile = path.Base(artifactLocation)
+				}
+				target := path.Join(contextDir, targetFile)
+				if _, err := os.Stat(target); err == nil {
+					// ensure the target does not exists before creating a new one
+					if err := os.Remove(target); err != nil {
+						return err
+					}
+				}
+				if err := os.Link(artifactLocation, target); err != nil {
 					return err
 				}
-			}
-			if err := os.Link(artifactLocation, target); err != nil {
-				return err
 			}
 		}
 	}

--- a/apps/distgo/cmd/publish/cmd_test.go
+++ b/apps/distgo/cmd/publish/cmd_test.go
@@ -376,7 +376,7 @@ group-id: com.palantir.distgo-cmd-test`,
 		productToArtifact := make(map[string]string)
 		for k, v := range artifacts {
 			require.Equal(t, 1, len(v.Keys()))
-			productToArtifact[k] = v.Get(v.Keys()[0])
+			productToArtifact[k] = v.Get(v.Keys()[0])[0]
 		}
 
 		handlerFunc = currCase.handler(productToArtifact)

--- a/apps/distgo/cmd/publish/publish_test.go
+++ b/apps/distgo/cmd/publish/publish_test.go
@@ -131,7 +131,7 @@ func TestPublishLocal(t *testing.T) {
 			},
 		},
 		{
-			name: "local publish for OSArch-bin product includes classifier in POM",
+			name: "local publish for OSArch-bin product",
 			buildSpec: func(projectDir string) params.ProductBuildSpecWithDeps {
 				specWithDeps, err := params.NewProductBuildSpecWithDeps(params.NewProductBuildSpec(projectDir, "publish-test-service", git.ProjectInfo{
 					Version:  "0.0.1",
@@ -149,9 +149,11 @@ func TestPublishLocal(t *testing.T) {
 					},
 					Dist: []params.Dist{{
 						Info: &params.OSArchsBinDistInfo{
-							OSArch: osarch.OSArch{
-								OS:   "darwin",
-								Arch: "amd64",
+							OSArchs: []osarch.OSArch{
+								{
+									OS:   "darwin",
+									Arch: "amd64",
+								},
 							},
 						},
 					}},
@@ -201,16 +203,79 @@ func TestPublishLocal(t *testing.T) {
 					},
 					Dist: []params.Dist{{
 						Info: &params.OSArchsBinDistInfo{
-							OSArch: osarch.OSArch{
-								OS:   "darwin",
-								Arch: "amd64",
+							OSArchs: []osarch.OSArch{
+								{
+									OS:   "darwin",
+									Arch: "amd64",
+								},
 							},
 						},
 					}, {
 						Info: &params.OSArchsBinDistInfo{
-							OSArch: osarch.OSArch{
+							OSArchs: []osarch.OSArch{
+								{
+									OS:   "linux",
+									Arch: "amd64",
+								},
+							},
+						},
+					}},
+					Publish: params.Publish{
+						GroupID: "com.palantir.distgo-publish-test",
+					},
+				}, params.Project{}), nil)
+				require.NoError(t, err)
+				return specWithDeps
+			},
+			wantPaths: []string{
+				"com/palantir/distgo-publish-test/publish-test-service/0.0.1/publish-test-service-0.0.1.pom",
+				"com/palantir/distgo-publish-test/publish-test-service/0.0.1/publish-test-service-0.0.1-darwin-amd64.tgz",
+				"com/palantir/distgo-publish-test/publish-test-service/0.0.1/publish-test-service-0.0.1-linux-amd64.tgz",
+			},
+			wantContent: map[string]string{
+				"com/palantir/distgo-publish-test/publish-test-service/0.0.1/publish-test-service-0.0.1.pom": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+					"<project xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\" xmlns=\"http://maven.apache.org/POM/4.0.0\"\n" +
+					"xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" +
+					"<modelVersion>4.0.0</modelVersion>\n" +
+					"<groupId>com.palantir.distgo-publish-test</groupId>\n" +
+					"<artifactId>publish-test-service</artifactId>\n" +
+					"<version>0.0.1</version>\n" +
+					"<packaging>tgz</packaging>\n" +
+					"</project>\n",
+			},
+		},
+		{
+			name: "local publish for OSArch-bin product with dist with multiple OS/Archs creates multiple artifacts but single POM",
+			buildSpec: func(projectDir string) params.ProductBuildSpecWithDeps {
+				specWithDeps, err := params.NewProductBuildSpecWithDeps(params.NewProductBuildSpec(projectDir, "publish-test-service", git.ProjectInfo{
+					Version:  "0.0.1",
+					Branch:   "0.0.1",
+					Revision: "0",
+				}, params.Product{
+					Build: params.Build{
+						MainPkg: "./.",
+						OSArchs: []osarch.OSArch{
+							{
+								OS:   "darwin",
+								Arch: "amd64",
+							},
+							{
 								OS:   "linux",
 								Arch: "amd64",
+							},
+						},
+					},
+					Dist: []params.Dist{{
+						Info: &params.OSArchsBinDistInfo{
+							OSArchs: []osarch.OSArch{
+								{
+									OS:   "darwin",
+									Arch: "amd64",
+								},
+								{
+									OS:   "linux",
+									Arch: "amd64",
+								},
 							},
 						},
 					}},

--- a/apps/distgo/config/config.go
+++ b/apps/distgo/config/config.go
@@ -183,8 +183,8 @@ type BinDist struct {
 }
 
 type OSArchBinDist struct {
-	// OSArch specifies the OS/architecture combination for this distribution.
-	OSArch *osarch.OSArch `yaml:"os-arch" json:"os-arch"`
+	// OSArchs specifies the OS/architecture combinations for this distribution.
+	OSArchs []osarch.OSArch `yaml:"os-archs" json:"os-archs"`
 }
 
 type SLSDist struct {
@@ -405,7 +405,7 @@ func (cfg *DistInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err := unmarshal(&rawOSArchBin); err != nil {
 			return err
 		}
-		if rawOSArchBin.Info.OSArch == nil {
+		if rawOSArchBin.Info.OSArchs == nil {
 			return errors.New("os-arch must be specified in configuration")
 		}
 		rawDistInfoConfig.Info = rawOSArchBin.Info
@@ -453,7 +453,7 @@ func (cfg *DistInfo) ToParam() (params.DistInfo, error) {
 			val := OSArchBinDist{}
 			decodeErr = mapstructure.Decode(cfg.Info, &val)
 			distInfo = &params.OSArchsBinDistInfo{
-				OSArch: *val.OSArch,
+				OSArchs: val.OSArchs,
 			}
 		case params.RPMDistType:
 			val := RPMDist{}
@@ -499,7 +499,7 @@ func (cfg *BinDist) ToParams() params.BinDistInfo {
 
 func (cfg *OSArchBinDist) ToParams() params.OSArchsBinDistInfo {
 	return params.OSArchsBinDistInfo{
-		OSArch: *cfg.OSArch,
+		OSArchs: cfg.OSArchs,
 	}
 }
 

--- a/apps/distgo/params/dist.go
+++ b/apps/distgo/params/dist.go
@@ -73,8 +73,8 @@ type DistInfo interface {
 }
 
 type OSArchsBinDistInfo struct {
-	// OSArch specifies the OS/architecture combination for this distribution.
-	OSArch osarch.OSArch
+	// OSArchs specifies the OS/architecture combinations for this distribution.
+	OSArchs []osarch.OSArch
 }
 
 func (i *OSArchsBinDistInfo) Type() DistInfoType {


### PR DESCRIPTION
Makes it possible to support the notion of classifiers (a single
distribution with multiple outputs of the same type). Updates
Publish code so that POM for dist is published once per set of
artifacts for a particular distribution.

Also fixes bug in "artifacts" where, if there were multiple
Dist configurations of the same type for a single product, only
the outputs for one of them would be reported.

Fixes #98