### PR TITLE
Make it so that os-archs property of os-arch-bin is optional

### DIFF
--- a/apps/distgo/config/config.go
+++ b/apps/distgo/config/config.go
@@ -183,7 +183,8 @@ type BinDist struct {
 }
 
 type OSArchBinDist struct {
-	// OSArchs specifies the OS/architecture combinations for this distribution.
+	// OSArchs specifies the GOOS and GOARCH pairs for which TGZ distributions are created. If blank, defaults to
+	// the GOOS and GOARCH of the host system at runtime.
 	OSArchs []osarch.OSArch `yaml:"os-archs" json:"os-archs"`
 }
 
@@ -404,9 +405,6 @@ func (cfg *DistInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		var rawOSArchBin typedRawConfig
 		if err := unmarshal(&rawOSArchBin); err != nil {
 			return err
-		}
-		if rawOSArchBin.Info.OSArchs == nil {
-			return errors.New("os-arch must be specified in configuration")
 		}
 		rawDistInfoConfig.Info = rawOSArchBin.Info
 	case params.RPMDistType:

--- a/apps/distgo/params/dist.go
+++ b/apps/distgo/params/dist.go
@@ -73,7 +73,8 @@ type DistInfo interface {
 }
 
 type OSArchsBinDistInfo struct {
-	// OSArchs specifies the OS/architecture combinations for this distribution.
+	// OSArchs specifies the GOOS and GOARCH pairs for which TGZ distributions are created. If blank, defaults to
+	// the GOOS and GOARCH of the host system at runtime.
 	OSArchs []osarch.OSArch
 }
 

--- a/apps/distgo/params/product.go
+++ b/apps/distgo/params/product.go
@@ -132,6 +132,12 @@ func NewProductBuildSpec(projectDir, productName string, gitProductInfo git.Proj
 			}
 		}
 
+		if osArchBinDistInfo, ok := currDistCfg.Info.(*OSArchsBinDistInfo); ok {
+			if len(osArchBinDistInfo.OSArchs) == 0 {
+				osArchBinDistInfo.OSArchs = []osarch.OSArch{osarch.Current()}
+			}
+		}
+
 		if projectCfg.DistScriptInclude != "" && currDistCfg.Script != "" {
 			currDistCfg.Script = strings.Join([]string{projectCfg.DistScriptInclude, currDistCfg.Script}, "\n")
 		}


### PR DESCRIPTION
Mirror behavior of build OS/Arch parameter and allow the OS/Archs
combination to be empty. If it is empty, it will default to
creating a distribution for the OS/Arch combination at runtime.

Fixes #128