### PR TITLE
Update pkg/pkgpath dependency

### DIFF
--- a/vendor/github.com/palantir/pkg/pkgpath/packages.go
+++ b/vendor/github.com/palantir/pkg/pkgpath/packages.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+// Copyright 2016 Palantir Technologies. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -235,6 +235,13 @@ func PackagesInDir(rootDir string, exclude matcher.Matcher) (Packages, error) {
 
 	allPkgs := make(map[string]string)
 	if err := filepath.Walk(dirAbsolutePath, func(currPath string, currInfo os.FileInfo, err error) error {
+		currRelPath, currRelPathErr := filepath.Rel(dirAbsolutePath, currPath)
+
+		// skip current path if it matches an exclude
+		if currRelPathErr == nil && exclude != nil && exclude.Match(currRelPath) {
+			return nil
+		}
+
 		if err != nil {
 			return err
 		}
@@ -243,14 +250,8 @@ func PackagesInDir(rootDir string, exclude matcher.Matcher) (Packages, error) {
 			return nil
 		}
 
-		currRelPath, err := filepath.Rel(dirAbsolutePath, currPath)
-		if err != nil {
-			return err
-		}
-
-		// if current path matches an include and does not match the exclude, include
-		if exclude != nil && exclude.Match(currRelPath) {
-			return nil
+		if currRelPathErr != nil {
+			return currRelPathErr
 		}
 
 		// create a filter for processing package files that only passes if it does not match an exclude

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -557,10 +557,10 @@
 			"revisionTime": "2017-04-06T01:49:46Z"
 		},
 		{
-			"checksumSHA1": "wFdDjAqsTus/qC39RSSB7liU124=",
+			"checksumSHA1": "3YbkHPlXjP7vJKhsTR6RqwUQH3I=",
 			"path": "github.com/palantir/pkg/pkgpath",
-			"revision": "c60ea2d471b77fae0cd4219bd329bd7e0e01d5b8",
-			"revisionTime": "2016-12-02T17:17:08Z"
+			"revision": "b5064fe62802edcac01f3cf1ad48ed7ee4aa8c3c",
+			"revisionTime": "2017-05-02T05:44:56Z"
 		},
 		{
 			"checksumSHA1": "cYHVn6ZfN+UH2SW5PWHSn1ym0wo=",


### PR DESCRIPTION
Fixes bug where determining the packages in a project would fail
if a directory or file could not be read, even if that directory
or file was excluded via configuration.

Fixes #136