### PR TITLE
Repackage a newer version of errcheck in order to use file-backed exclusion

### DIFF
--- a/apps/okgo/generated_src/internal/github.com/kisielk/errcheck/internal/errcheck/errcheck.go
+++ b/apps/okgo/generated_src/internal/github.com/kisielk/errcheck/internal/errcheck/errcheck.go
@@ -34,8 +34,9 @@ var (
 
 // UncheckedError indicates the position of an unchecked error return.
 type UncheckedError struct {
-	Pos	token.Position
-	Line	string
+	Pos		token.Position
+	Line		string
+	FuncName	string
 }
 
 // UncheckedErrors is returned from the CheckPackage function if the package contains
@@ -106,6 +107,30 @@ type Checker struct {
 
 	// If true, checking of of _test.go files is disabled
 	WithoutTests	bool
+
+	exclude	map[string]bool
+}
+
+func NewChecker() *Checker {
+	c := Checker{}
+	c.SetExclude(map[string]bool{})
+	return &c
+}
+
+func (c *Checker) SetExclude(l map[string]bool) {
+	// Default exclude for stdlib functions
+	c.exclude = map[string]bool{
+		"math/rand.Read":		true,
+		"(*math/rand.Rand).Read":	true,
+
+		"(*bytes.Buffer).Write":	true,
+		"(*bytes.Buffer).WriteByte":	true,
+		"(*bytes.Buffer).WriteRune":	true,
+		"(*bytes.Buffer).WriteString":	true,
+	}
+	for k := range l {
+		c.exclude[k] = true
+	}
 }
 
 func (c *Checker) logf(msg string, args ...interface{}) {
@@ -130,11 +155,7 @@ func (c *Checker) load(paths ...string) (*loader.Program, error) {
 		return nil, fmt.Errorf("unhandled extra arguments: %v", rest)
 	}
 
-	prog, err := loadcfg.Load()
-	if err != nil {
-		fmt.Println("loadcfg.Load failed:", err)
-	}
-	return prog, err
+	return loadcfg.Load()
 }
 
 // CheckPackages checks packages for errors.
@@ -164,6 +185,7 @@ func (c *Checker) CheckPackages(paths ...string) error {
 				blank:		c.Blank,
 				asserts:	c.Asserts,
 				lines:		make(map[string][]string),
+				exclude:	c.exclude,
 				errors:		[]UncheckedError{},
 			}
 
@@ -190,11 +212,44 @@ type visitor struct {
 	blank	bool
 	asserts	bool
 	lines	map[string][]string
+	exclude	map[string]bool
 
 	errors	[]UncheckedError
 }
 
+func (v *visitor) fullName(call *ast.CallExpr) (string, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	fn, ok := v.pkg.ObjectOf(sel.Sel).(*types.Func)
+	if !ok {
+		// Shouldn't happen, but be paranoid
+		return "", false
+	}
+	// The name is fully qualified by the import path, possible type,
+	// function/method name and pointer receiver.
+	//
+	// TODO(dh): vendored packages will have /vendor/ in their name,
+	// thus not matching vendored standard library packages. If we
+	// want to support vendored stdlib packages, we need to implement
+	// FullName with our own logic.
+	return fn.FullName(), true
+}
+
+func (v *visitor) excludeCall(call *ast.CallExpr) bool {
+	if name, ok := v.fullName(call); ok {
+		return v.exclude[name]
+	}
+
+	return false
+}
+
 func (v *visitor) ignoreCall(call *ast.CallExpr) bool {
+	if v.excludeCall(call) {
+		return true
+	}
+
 	// Try to get an identifier.
 	// Currently only supports simple expressions:
 	//     1. f()
@@ -301,7 +356,7 @@ func (v *visitor) isRecover(call *ast.CallExpr) bool {
 	return false
 }
 
-func (v *visitor) addErrorAtPosition(position token.Pos) {
+func (v *visitor) addErrorAtPosition(position token.Pos, call *ast.CallExpr) {
 	pos := v.prog.Fset.Position(position)
 	lines, ok := v.lines[pos.Filename]
 	if !ok {
@@ -313,7 +368,13 @@ func (v *visitor) addErrorAtPosition(position token.Pos) {
 	if pos.Line-1 < len(lines) {
 		line = strings.TrimSpace(lines[pos.Line-1])
 	}
-	v.errors = append(v.errors, UncheckedError{pos, line})
+
+	var name string
+	if call != nil {
+		name, _ = v.fullName(call)
+	}
+
+	v.errors = append(v.errors, UncheckedError{pos, line, name})
 }
 
 func readfile(filename string) []string {
@@ -335,16 +396,16 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 	case *ast.ExprStmt:
 		if call, ok := stmt.X.(*ast.CallExpr); ok {
 			if !v.ignoreCall(call) && v.callReturnsError(call) {
-				v.addErrorAtPosition(call.Lparen)
+				v.addErrorAtPosition(call.Lparen, call)
 			}
 		}
 	case *ast.GoStmt:
 		if !v.ignoreCall(stmt.Call) && v.callReturnsError(stmt.Call) {
-			v.addErrorAtPosition(stmt.Call.Lparen)
+			v.addErrorAtPosition(stmt.Call.Lparen, stmt.Call)
 		}
 	case *ast.DeferStmt:
 		if !v.ignoreCall(stmt.Call) && v.callReturnsError(stmt.Call) {
-			v.addErrorAtPosition(stmt.Call.Lparen)
+			v.addErrorAtPosition(stmt.Call.Lparen, stmt.Call)
 		}
 	case *ast.AssignStmt:
 		if len(stmt.Rhs) == 1 {
@@ -362,7 +423,7 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 						// We shortcut calls to recover() because errorsByArg can't
 						// check its return types for errors since it returns interface{}.
 						if id.Name == "_" && (v.isRecover(call) || isError[i]) {
-							v.addErrorAtPosition(id.NamePos)
+							v.addErrorAtPosition(id.NamePos, call)
 						}
 					}
 				}
@@ -376,10 +437,10 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 				}
 				if len(stmt.Lhs) < 2 {
 					// assertion result not read
-					v.addErrorAtPosition(stmt.Rhs[0].Pos())
+					v.addErrorAtPosition(stmt.Rhs[0].Pos(), nil)
 				} else if id, ok := stmt.Lhs[1].(*ast.Ident); ok && v.blank && id.Name == "_" {
 					// assertion result ignored
-					v.addErrorAtPosition(id.NamePos)
+					v.addErrorAtPosition(id.NamePos, nil)
 				}
 			}
 		} else {
@@ -395,7 +456,7 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 							continue
 						}
 						if id.Name == "_" && v.callReturnsError(call) {
-							v.addErrorAtPosition(id.NamePos)
+							v.addErrorAtPosition(id.NamePos, call)
 						}
 					} else if assert, ok := stmt.Rhs[i].(*ast.TypeAssertExpr); ok {
 						if !v.asserts {
@@ -405,7 +466,7 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 							// Shouldn't happen anyway, no multi assignment in type switches
 							continue
 						}
-						v.addErrorAtPosition(id.NamePos)
+						v.addErrorAtPosition(id.NamePos, nil)
 					}
 				}
 			}

--- a/apps/okgo/generated_src/internal/github.com/kisielk/errcheck/main.go
+++ b/apps/okgo/generated_src/internal/github.com/kisielk/errcheck/main.go
@@ -1,6 +1,7 @@
 package amalgomated
 
 import (
+	"bufio"
 	"github.com/palantir/godel/apps/okgo/generated_src/internal/github.com/kisielk/errcheck/amalgomated_flag"
 	"fmt"
 	"os"
@@ -82,7 +83,7 @@ func (f *tagsFlag) Set(s string) error {
 
 var dotStar = regexp.MustCompile(".*")
 
-func reportUncheckedErrors(e *errcheck.UncheckedErrors) {
+func reportUncheckedErrors(e *errcheck.UncheckedErrors, verbose bool) {
 	wd, err := os.Getwd()
 	if err != nil {
 		wd = ""
@@ -95,14 +96,19 @@ func reportUncheckedErrors(e *errcheck.UncheckedErrors) {
 				pos = newPos
 			}
 		}
-		fmt.Printf("%s:\t%s\n", pos, uncheckedError.Line)
+
+		if verbose && uncheckedError.FuncName != "" {
+			fmt.Printf("%s:\t%s\t%s\n", pos, uncheckedError.FuncName, uncheckedError.Line)
+		} else {
+			fmt.Printf("%s:\t%s\n", pos, uncheckedError.Line)
+		}
 	}
 }
 
 func mainCmd(args []string) int {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
-	checker := &errcheck.Checker{}
+	checker := errcheck.NewChecker()
 	paths, err := parseFlags(checker, args)
 	if err != exitCodeOk {
 		return err
@@ -110,7 +116,7 @@ func mainCmd(args []string) int {
 
 	if err := checker.CheckPackages(paths...); err != nil {
 		if e, ok := err.(*errcheck.UncheckedErrors); ok {
-			reportUncheckedErrors(e)
+			reportUncheckedErrors(e, checker.Verbose)
 			return exitUncheckedError
 		} else if err == errcheck.ErrNoGoFiles {
 			fmt.Fprintln(os.Stderr, err)
@@ -137,11 +143,37 @@ func parseFlags(checker *errcheck.Checker, args []string) ([]string, int) {
 	ignore := ignoreFlag(map[string]*regexp.Regexp{
 		"fmt": dotStar,
 	})
-	flags.Var(ignore, "ignore", "comma-separated list of pairs of the form pkg:regex\n"+
-		"            the regex is used to ignore names within pkg")
+	flags.Var(ignore, "ignore", "[deprecated] comma-separated list of pairs of the form pkg:regex\n"+
+		"            the regex is used to ignore names within pkg.")
+
+	var excludeFile string
+	flags.StringVar(&excludeFile, "exclude", "", "Path to a file containing a list of functions to exclude from checking")
 
 	if err := flags.Parse(args[1:]); err != nil {
 		return nil, exitFatalError
+	}
+
+	if excludeFile != "" {
+		exclude := make(map[string]bool)
+		fh, err := os.Open(excludeFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not read exclude file: %s\n", err)
+			return nil, exitFatalError
+		}
+		scanner := bufio.NewScanner(fh)
+		for scanner.Scan() {
+			name := scanner.Text()
+			exclude[name] = true
+
+			if checker.Verbose {
+				fmt.Printf("Excluding %s\n", name)
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			fmt.Fprintf(os.Stderr, "Could not read exclude file: %s\n", err)
+			return nil, exitFatalError
+		}
+		checker.SetExclude(exclude)
 	}
 
 	checker.Tags = tags

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -280,16 +280,16 @@
 			"revisionTime": "2016-11-15T22:06:34Z"
 		},
 		{
-			"checksumSHA1": "eFFuFUZGU+CFlgpCn/k5raGSlbo=",
+			"checksumSHA1": "eva6MIhWu7k6BWB8G7OOYTJnpeA=",
 			"path": "github.com/kisielk/errcheck",
-			"revision": "9c1292e1c962175f76516859f4a88aabd86dc495",
-			"revisionTime": "2016-09-17T21:32:20Z"
+			"revision": "23699b7e2cbfdb89481023524954ba2aeff6be90",
+			"revisionTime": "2017-03-17T17:34:29Z"
 		},
 		{
-			"checksumSHA1": "9bqc0nHozWI3MQaCYY5KKtqOXOw=",
+			"checksumSHA1": "GP25rgIPshJh0tpiBg3Z8Dexqj4=",
 			"path": "github.com/kisielk/errcheck/internal/errcheck",
-			"revision": "9c1292e1c962175f76516859f4a88aabd86dc495",
-			"revisionTime": "2016-09-17T21:32:20Z"
+			"revision": "23699b7e2cbfdb89481023524954ba2aeff6be90",
+			"revisionTime": "2017-03-17T17:34:29Z"
 		},
 		{
 			"checksumSHA1": "hDuX7ev2IPZqz+3dbmvNNE6rQd4=",


### PR DESCRIPTION
Specifically, to use the functionality provided by [kisielk/errcheck#116](https://github.com/kisielk/errcheck/pull/116).