### PR TITLE
Update default value for os-arch-bin dist type

### DIFF
--- a/apps/distgo/params/product.go
+++ b/apps/distgo/params/product.go
@@ -134,7 +134,7 @@ func NewProductBuildSpec(projectDir, productName string, gitProductInfo git.Proj
 
 		if osArchBinDistInfo, ok := currDistCfg.Info.(*OSArchsBinDistInfo); ok {
 			if len(osArchBinDistInfo.OSArchs) == 0 {
-				osArchBinDistInfo.OSArchs = []osarch.OSArch{osarch.Current()}
+				osArchBinDistInfo.OSArchs = buildSpec.Build.OSArchs
 			}
 		}
 


### PR DESCRIPTION
Change it so that default targets of the os-arch-bin dist type
match the os/arch types of the input build artifacts.