### PR TITLE
Change behavior of bin dist when omit-init-sh is not specified

### DIFF
--- a/apps/distgo/cmd/dist/dist_test.go
+++ b/apps/distgo/cmd/dist/dist_test.go
@@ -1084,6 +1084,83 @@ daemon: true
 			},
 		},
 		{
+			name: "bin dist includes init script when OmitInitSh is false",
+			spec: func(projectDir string) params.ProductBuildSpecWithDeps {
+				specWithDeps, err := params.NewProductBuildSpecWithDeps(params.NewProductBuildSpec(
+					projectDir,
+					"foo",
+					git.ProjectInfo{
+						Version: "0.1.0",
+					},
+					params.Product{
+						Build: params.Build{
+							MainPkg: "./.",
+						},
+						Dist: []params.Dist{{
+							Info: &params.BinDistInfo{
+								OmitInitSh: false,
+							},
+						}},
+					},
+					params.Project{},
+				), nil)
+				require.NoError(t, err)
+				return specWithDeps
+			},
+			preDistAction: func(projectDir string, buildSpec params.ProductBuildSpec) {
+				gittest.CreateGitTag(t, projectDir, "0.1.0")
+			},
+			validate: func(caseNum int, name string, projectDir string) {
+				// bin directory exists in top-level directory
+				fileInfo, err := os.Stat(path.Join(projectDir, "dist", "foo-0.1.0", "bin"))
+				require.NoError(t, err)
+				assert.True(t, fileInfo.IsDir(), "Case %d: %s", caseNum, name)
+
+				// init script for product should exist
+				fileInfo, err = os.Stat(path.Join(projectDir, "dist", "foo-0.1.0", "bin", "foo.sh"))
+				require.NoError(t, err)
+				assert.True(t, !fileInfo.IsDir(), "Case %d: %s", caseNum, name)
+			},
+		},
+		{
+			name: "bin dist omits init script when OmitInitSh is true",
+			spec: func(projectDir string) params.ProductBuildSpecWithDeps {
+				specWithDeps, err := params.NewProductBuildSpecWithDeps(params.NewProductBuildSpec(
+					projectDir,
+					"foo",
+					git.ProjectInfo{
+						Version: "0.1.0",
+					},
+					params.Product{
+						Build: params.Build{
+							MainPkg: "./.",
+						},
+						Dist: []params.Dist{{
+							Info: &params.BinDistInfo{
+								OmitInitSh: true,
+							},
+						}},
+					},
+					params.Project{},
+				), nil)
+				require.NoError(t, err)
+				return specWithDeps
+			},
+			preDistAction: func(projectDir string, buildSpec params.ProductBuildSpec) {
+				gittest.CreateGitTag(t, projectDir, "0.1.0")
+			},
+			validate: func(caseNum int, name string, projectDir string) {
+				// bin directory exists in top-level directory
+				fileInfo, err := os.Stat(path.Join(projectDir, "dist", "foo-0.1.0", "bin"))
+				require.NoError(t, err)
+				assert.True(t, fileInfo.IsDir(), "Case %d: %s", caseNum, name)
+
+				// init script for product should exist
+				_, err = os.Stat(path.Join(projectDir, "dist", "foo-0.1.0", "bin", "foo.sh"))
+				assert.True(t, os.IsNotExist(err))
+			},
+		},
+		{
 			name: "osarch dist produces archive that contains executable for current OS/Arch by default",
 			spec: func(projectDir string) params.ProductBuildSpecWithDeps {
 				specWithDeps, err := params.NewProductBuildSpecWithDeps(params.NewProductBuildSpec(

--- a/apps/distgo/config/config.go
+++ b/apps/distgo/config/config.go
@@ -178,9 +178,10 @@ type DistInfo struct {
 }
 
 type BinDist struct {
-	// OmitInitSh specifies whether or not the distribution should omit the auto-generated "init.sh" invocation
-	// script. If true, the "init.sh" script will not be generated and included in the output distribution.
-	OmitInitSh bool `yaml:"omit-init-sh" json:"omit-init-sh"`
+	// OmitInitSh specifies whether or not the distribution should omit the auto-generated initialization script for the
+	// product (a script in the "bin" directory that chooses the binary to invoke based on the host platform). If the
+	// value is present and false, then the initialization script will be generated; otherwise, it will not.
+	OmitInitSh *bool `yaml:"omit-init-sh" json:"omit-init-sh"`
 	// InitShTemplateFile is the relative path to the template that should be used to generate the "init.sh" script.
 	// If the value is absent, the default template will be used.
 	InitShTemplateFile string `yaml:"init-sh-template-file" json:"init-sh-template-file"`
@@ -480,7 +481,7 @@ func (cfg *DistInfo) ToParam() (params.DistInfo, error) {
 			val := BinDist{}
 			decodeErr = mapstructure.Decode(cfg.Info, &val)
 			distInfo = &params.BinDistInfo{
-				OmitInitSh:         val.OmitInitSh,
+				OmitInitSh:         val.OmitInitSh == nil || *val.OmitInitSh,
 				InitShTemplateFile: val.InitShTemplateFile,
 			}
 		case params.ManualDistType:
@@ -532,7 +533,7 @@ func convertMapKeysToCamelCase(input interface{}) {
 
 func (cfg *BinDist) ToParams() params.BinDistInfo {
 	return params.BinDistInfo{
-		OmitInitSh:         cfg.OmitInitSh,
+		OmitInitSh:         cfg.OmitInitSh == nil || *cfg.OmitInitSh,
 		InitShTemplateFile: cfg.InitShTemplateFile,
 	}
 }

--- a/apps/distgo/config/config_test.go
+++ b/apps/distgo/config/config_test.go
@@ -138,6 +138,37 @@ echo "main.year=$YEAR"
 			      main-pkg: ./cmd/test
 			    dist:
 			      dist-type:
+			        type: bin
+			`,
+			want: func() config.Project {
+				return config.Project{
+					Products: map[string]config.Product{
+						"test": {
+							Build: config.Build{
+								MainPkg: "./cmd/test",
+							},
+							Dist: []config.Dist{{
+								DistType: config.DistInfo{
+									Type: string(params.BinDistType),
+									Info: config.BinDist{
+										OmitInitSh: nil,
+									},
+								},
+							}},
+						},
+					},
+					Exclude: matcher.NamesPathsCfg{},
+				}
+			},
+		},
+		{
+			yml: `
+			products:
+			  test:
+			    build:
+			      main-pkg: ./cmd/test
+			    dist:
+			      dist-type:
 			        type: os-arch-bin
 			        info:
 			          os-archs:


### PR DESCRIPTION
Make it so that not specifying "omit-init-sh" is config is
equivalent to setting the value to "true" (rather than "false").