### PR TITLE
Touch up format strings and style in distgo

### DIFF
--- a/apps/distgo/cmd/publish/almanac.go
+++ b/apps/distgo/cmd/publish/almanac.go
@@ -57,7 +57,7 @@ func (a *AlmanacInfo) CheckProduct(client *http.Client, product string) error {
 }
 
 func (a *AlmanacInfo) CreateProduct(client *http.Client, product string) error {
-	_, err := a.do(client, http.MethodPost, "/v1/units/products", fmt.Sprintf(`{"name":"%v"}`, product))
+	_, err := a.do(client, http.MethodPost, "/v1/units/products", fmt.Sprintf(`{"name":"%s"}`, product))
 	return err
 }
 
@@ -67,7 +67,7 @@ func (a *AlmanacInfo) CheckProductBranch(client *http.Client, product, branch st
 }
 
 func (a *AlmanacInfo) CreateProductBranch(client *http.Client, product, branch string) error {
-	_, err := a.do(client, http.MethodPost, strings.Join([]string{"/v1/units", product}, "/"), fmt.Sprintf(`{"name":"%v"}`, branch))
+	_, err := a.do(client, http.MethodPost, strings.Join([]string{"/v1/units", product}, "/"), fmt.Sprintf(`{"name":"%s"}`, branch))
 	return err
 }
 
@@ -147,11 +147,11 @@ func (a *AlmanacInfo) do(client *http.Client, method, endpoint, body string) (rB
 	}()
 	responseBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to read response body for %v", destURL.String())
+		return nil, errors.Wrapf(err, "Failed to read response body for %s", destURL.String())
 	}
 
 	if resp.StatusCode >= http.StatusBadRequest {
-		return responseBytes, errors.Errorf("Received non-success status code: %v. Response: %s", resp.Status, string(responseBytes))
+		return responseBytes, errors.Errorf("Received non-success status code: %s. Response: %s", resp.Status, string(responseBytes))
 	}
 
 	return responseBytes, nil
@@ -168,11 +168,11 @@ func addAlmanacAuthForRequest(accessID, secret, body string, req *http.Request) 
 	timestamp := time.Now().Unix()
 	req.Header.Add("X-timestamp", fmt.Sprintf("%d", timestamp))
 
-	hmac, err := hmacSHA1(fmt.Sprintf("%v%d%v", req.URL.String(), timestamp, body), secret)
+	hmac, err := hmacSHA1(fmt.Sprint(req.URL.String(), timestamp, body), secret)
 	if err != nil {
 		return err
 	}
-	req.Header.Add("X-authorization", fmt.Sprintf("%v:%v", accessID, hmac))
+	req.Header.Add("X-authorization", fmt.Sprintf("%s:%s", accessID, hmac))
 	return nil
 }
 

--- a/apps/distgo/cmd/publish/artifactory_publish.go
+++ b/apps/distgo/cmd/publish/artifactory_publish.go
@@ -92,25 +92,25 @@ func (a *ArtifactoryConnectionInfo) Publish(buildSpec params.ProductBuildSpec, p
 func computeArtifactChecksums(artifactoryURL, repoKey, username, password string, paths ProductPaths, stdout io.Writer) error {
 	for _, currArtifactPath := range paths.artifactPaths {
 		currArtifactURL := strings.Join([]string{paths.productPath, path.Base(currArtifactPath)}, "/")
-		if err := artifactorySetSHA256Checksum(artifactoryURL, repoKey, currArtifactURL, username, password, stdout); err != nil {
+		if err := artifactorySetSHA256Checksum(artifactoryURL, repoKey, currArtifactURL, username, password); err != nil {
 			return errors.Wrapf(err, "")
 		}
 	}
 	pomPath := strings.Join([]string{paths.productPath, path.Base(paths.pomFilePath)}, "/")
-	if err := artifactorySetSHA256Checksum(artifactoryURL, repoKey, pomPath, username, password, stdout); err != nil {
+	if err := artifactorySetSHA256Checksum(artifactoryURL, repoKey, pomPath, username, password); err != nil {
 		return errors.Wrapf(err, "")
 	}
 	return nil
 }
 
-func artifactorySetSHA256Checksum(baseURLString, repoKey, filePath, username, password string, stdout io.Writer) (rErr error) {
+func artifactorySetSHA256Checksum(baseURLString, repoKey, filePath, username, password string) (rErr error) {
 	apiURLString := baseURLString + "/api/checksum/sha256"
 	uploadURL, err := url.Parse(apiURLString)
 	if err != nil {
-		return errors.Wrapf(err, "failed to parse %v as URL", apiURLString)
+		return errors.Wrapf(err, "failed to parse %s as URL", apiURLString)
 	}
 
-	jsonContent := fmt.Sprintf(`{"repoKey":"%v","path":"%v"}`, repoKey, filePath)
+	jsonContent := fmt.Sprintf(`{"repoKey":"%s","path":"%s"}`, repoKey, filePath)
 	reader := strings.NewReader(jsonContent)
 
 	header := http.Header{}
@@ -126,7 +126,7 @@ func artifactorySetSHA256Checksum(baseURLString, repoKey, filePath, username, pa
 
 	resp, err := http.DefaultClient.Do(&req)
 	if err != nil {
-		return errors.Wrapf(err, "failed to trigger computation of SHA-256 checksum for %v", filePath)
+		return errors.Wrapf(err, "failed to trigger computation of SHA-256 checksum for %s", filePath)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil && rErr == nil {
@@ -135,7 +135,7 @@ func artifactorySetSHA256Checksum(baseURLString, repoKey, filePath, username, pa
 	}()
 
 	if resp.StatusCode >= http.StatusBadRequest {
-		return errors.Errorf("triggering computation of SHA-256 checksum for %v resulted in response: %v", filePath, resp.Status)
+		return errors.Errorf("triggering computation of SHA-256 checksum for %s resulted in response: %s", filePath, resp.Status)
 	}
 	return nil
 }

--- a/apps/distgo/cmd/publish/bintray_publish.go
+++ b/apps/distgo/cmd/publish/bintray_publish.go
@@ -73,7 +73,7 @@ func (b *BintrayConnectionInfo) addToDownloadsList(buildSpec params.ProductBuild
 func (b *BintrayConnectionInfo) runBintrayCommand(urlString, httpMethod, jsonContent, cmdMsg string, stdout io.Writer) (rErr error) {
 	url, err := url.Parse(urlString)
 	if err != nil {
-		return errors.Wrapf(err, "failed to parse %v as URL", urlString)
+		return errors.Wrapf(err, "failed to parse %s as URL", urlString)
 	}
 
 	capitalizedMsg := cmdMsg
@@ -110,7 +110,7 @@ func (b *BintrayConnectionInfo) runBintrayCommand(urlString, httpMethod, jsonCon
 	}()
 
 	if resp.StatusCode >= http.StatusBadRequest {
-		return errors.Errorf("%s resulted in response: %v", cmdMsg, resp.Status)
+		return errors.Errorf("%s resulted in response: %s", cmdMsg, resp.Status)
 	}
 
 	fmt.Fprint(stdout, "done")

--- a/apps/distgo/cmd/publish/cmd_test.go
+++ b/apps/distgo/cmd/publish/cmd_test.go
@@ -57,7 +57,7 @@ func TestPublishBatchErrors(t *testing.T) {
 	wd, err := os.Getwd()
 	defer func() {
 		if err := os.Chdir(wd); err != nil {
-			fmt.Printf("Failed to restore working directory to %v: %v\n", wd, err)
+			fmt.Printf("Failed to restore working directory to %s: %v\n", wd, err)
 		}
 	}()
 	require.NoError(t, err)
@@ -189,7 +189,7 @@ func TestArtifactoryPublishChecksums(t *testing.T) {
 	wd, err := os.Getwd()
 	defer func() {
 		if err := os.Chdir(wd); err != nil {
-			fmt.Printf("Failed to restore working directory to %v: %v\n", wd, err)
+			fmt.Printf("Failed to restore working directory to %s: %v\n", wd, err)
 		}
 	}()
 	require.NoError(t, err)
@@ -421,7 +421,7 @@ func TestAlmanacPublishCheckURL(t *testing.T) {
 	wd, err := os.Getwd()
 	defer func() {
 		if err := os.Chdir(wd); err != nil {
-			fmt.Printf("Failed to restore working directory to %v: %v\n", wd, err)
+			fmt.Printf("Failed to restore working directory to %s: %v\n", wd, err)
 		}
 	}()
 	require.NoError(t, err)

--- a/apps/distgo/cmd/publish/local_publish.go
+++ b/apps/distgo/cmd/publish/local_publish.go
@@ -33,7 +33,7 @@ type LocalPublishInfo struct {
 func (l *LocalPublishInfo) Publish(buildSpec params.ProductBuildSpec, paths ProductPaths, stdout io.Writer) ([]string, error) {
 	productPath := path.Join(l.Path, paths.productPath)
 	if err := os.MkdirAll(productPath, 0755); err != nil {
-		return nil, errors.Wrapf(err, "Failed to create path to %v", productPath)
+		return nil, errors.Wrapf(err, "Failed to create path to %s", productPath)
 	}
 
 	if _, err := copyArtifact(paths.pomFilePath, productPath, stdout); err != nil {
@@ -53,6 +53,6 @@ func (l *LocalPublishInfo) Publish(buildSpec params.ProductBuildSpec, paths Prod
 
 func copyArtifact(src, dstDir string, stdout io.Writer) (string, error) {
 	dst := path.Join(dstDir, path.Base(src))
-	fmt.Fprintf(stdout, "Copying %v to %v\n", src, dst)
+	fmt.Fprintf(stdout, "Copying %s to %s\n", src, dst)
 	return dst, shutil.CopyFile(src, dst, false)
 }

--- a/apps/distgo/cmd/publish/publish.go
+++ b/apps/distgo/cmd/publish/publish.go
@@ -54,7 +54,7 @@ func Run(buildSpecWithDeps params.ProductBuildSpecWithDeps, publisher Publisher,
 		// verify that distribution to publish exists
 		for _, artifactPath := range dist.FullArtifactsPaths(dist.ToDister(currDistCfg.Info), buildSpec, currDistCfg) {
 			if _, err := os.Stat(artifactPath); os.IsNotExist(err) {
-				return errors.Errorf("distribution for %v does not exist at %v", buildSpec.ProductName, artifactPath)
+				return errors.Errorf("distribution for %s does not exist at %s", buildSpec.ProductName, artifactPath)
 			}
 		}
 
@@ -65,13 +65,13 @@ func Run(buildSpecWithDeps params.ProductBuildSpecWithDeps, publisher Publisher,
 
 		artifactURLs, err := publisher.Publish(buildSpec, paths, stdout)
 		if err != nil {
-			return fmt.Errorf("Publish failed for %v: %v", buildSpec.ProductName, err)
+			return fmt.Errorf("Publish failed for %s: %v", buildSpec.ProductName, err)
 		}
 
 		if almanacInfo != nil {
 			for _, currArtifactURL := range artifactURLs {
 				if err := almanacPublish(currArtifactURL, *almanacInfo, buildSpec, currDistCfg, stdout); err != nil {
-					return fmt.Errorf("Almanac publish failed for %v: %v", buildSpec.ProductName, err)
+					return fmt.Errorf("Almanac publish failed for %s: %v", buildSpec.ProductName, err)
 				}
 			}
 		}
@@ -111,7 +111,7 @@ func productPath(buildSpecWithDeps params.ProductBuildSpecWithDeps, distCfg para
 
 	pomFilePath := pomFilePath(buildSpec, distCfg)
 	if err := ioutil.WriteFile(pomFilePath, pomBytes, 0644); err != nil {
-		return ProductPaths{}, errors.Wrapf(err, "failed to write POM file to %v", pomFilePath)
+		return ProductPaths{}, errors.Wrapf(err, "failed to write POM file to %s", pomFilePath)
 	}
 
 	return ProductPaths{
@@ -178,7 +178,7 @@ type artifactExistsFunc func(fi fileInfo, dstFileName, username, password string
 func newFileInfo(pathToFile string) (fileInfo, error) {
 	bytes, err := ioutil.ReadFile(pathToFile)
 	if err != nil {
-		return fileInfo{}, errors.Wrapf(err, "Failed to read file %v", pathToFile)
+		return fileInfo{}, errors.Wrapf(err, "Failed to read file %s", pathToFile)
 	}
 
 	sha1Bytes := sha1.Sum(bytes)
@@ -211,10 +211,10 @@ func (b BasicConnectionInfo) uploadFile(filePath, baseURL, artifactPath string, 
 
 	uploadURL, err := url.Parse(rawUploadURL)
 	if err != nil {
-		return rawUploadURL, errors.Wrapf(err, "Failed to parse %v as URL", rawUploadURL)
+		return rawUploadURL, errors.Wrapf(err, "Failed to parse %s as URL", rawUploadURL)
 	}
 
-	fmt.Fprintf(stdout, "Uploading %v to %v\n", fileInfo.path, rawUploadURL)
+	fmt.Fprintf(stdout, "Uploading %s to %s\n", fileInfo.path, rawUploadURL)
 
 	header := http.Header{}
 	addChecksumToHeader(header, "Md5", fileInfo.checksums.MD5)
@@ -239,7 +239,7 @@ func (b BasicConnectionInfo) uploadFile(filePath, baseURL, artifactPath string, 
 
 	resp, err := http.DefaultClient.Do(&req)
 	if err != nil {
-		return rawUploadURL, errors.Wrapf(err, "failed to upload %v to %v", fileInfo.path, rawUploadURL)
+		return rawUploadURL, errors.Wrapf(err, "failed to upload %s to %s", fileInfo.path, rawUploadURL)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil && rErr == nil {
@@ -248,7 +248,7 @@ func (b BasicConnectionInfo) uploadFile(filePath, baseURL, artifactPath string, 
 	}()
 
 	if resp.StatusCode >= http.StatusBadRequest {
-		msg := fmt.Sprintf("uploading %v to %v resulted in response %q", fileInfo.path, rawUploadURL, resp.Status)
+		msg := fmt.Sprintf("uploading %s to %s resulted in response %q", fileInfo.path, rawUploadURL, resp.Status)
 		if body, err := ioutil.ReadAll(resp.Body); err == nil {
 			bodyStr := string(body)
 			if bodyStr != "" {
@@ -261,8 +261,8 @@ func (b BasicConnectionInfo) uploadFile(filePath, baseURL, artifactPath string, 
 	return rawUploadURL, nil
 }
 
-func addChecksumToHeader(header http.Header, checksumName string, checksum string) {
-	header.Add(fmt.Sprintf("X-Checksum-%v", checksumName), checksum)
+func addChecksumToHeader(header http.Header, checksumName, checksum string) {
+	header.Add(fmt.Sprintf("X-Checksum-%s", checksumName), checksum)
 }
 
 func pomFilePath(buildSpec params.ProductBuildSpec, distCfg params.Dist) string {


### PR DESCRIPTION
Use %s rather than %v when printing string variables and clean
up minor style issues.