### PR TITLE
Change behavior of test tags

### DIFF
--- a/apps/gunit/integration_test/integration_test.go
+++ b/apps/gunit/integration_test/integration_test.go
@@ -195,7 +195,7 @@ func TestRun(t *testing.T) {
 			wantError: "(?s).+1 package had failing tests:.+",
 		},
 		{
-			name: "tag will skip excluded tests",
+			name: "tag skips excluded tests",
 			filesToCreate: []gofiles.GoFileSpec{
 				{
 					RelPath: "foo_test.go",
@@ -400,7 +400,7 @@ func TestRun(t *testing.T) {
 			wantError: "(?s).+2 packages had failing tests:.+",
 		},
 		{
-			name: "only non-tagged tests are run if multiple tags are specified and tests are run without arguments",
+			name: "only non-tagged tests are run if none is specified as tag",
 			filesToCreate: []gofiles.GoFileSpec{
 				{
 					RelPath: "foo_test.go",
@@ -438,6 +438,9 @@ func TestRun(t *testing.T) {
 					  paths:
 					    - "vendor"
 					`),
+			args: []string{
+				"--tags", "none",
+			},
 			wantMatch: func(currCaseTmpDir string) string {
 				return `(?s)` +
 					`--- FAIL: TestFoo (.+)\n.+foo_test.go:[0-9]+: fooFail.+FAIL\t` + pkgName(t, currCaseTmpDir) + `\t[0-9.]+s.+`
@@ -445,41 +448,7 @@ func TestRun(t *testing.T) {
 			wantError: "(?s).+1 package had failing tests:.+",
 		},
 		{
-			name: "tags specified with uppercase letters works",
-			filesToCreate: []gofiles.GoFileSpec{
-				{
-					RelPath: "foo_test.go",
-					Src: `package foo
-					import "testing"
-					func TestFoo(t *testing.T) {
-						t.Errorf("fooFail")
-					}`,
-				},
-				{
-					RelPath: "bar/bar_test.go",
-					Src: `package bar
-					import "testing"
-					func TestBar(t *testing.T) {
-						t.Errorf("barFail")
-					}`,
-				},
-			},
-			config: unindent(`tags:
-					  Bar:
-					    paths:
-					      - "bar"
-					exclude:
-					  paths:
-					    - "vendor"
-					`),
-			wantMatch: func(currCaseTmpDir string) string {
-				return `(?s)` +
-					`--- FAIL: TestFoo (.+)\n.+foo_test.go:[0-9]+: fooFail.+FAIL\t` + pkgName(t, currCaseTmpDir) + `\t[0-9.]+s.+`
-			},
-			wantError: "(?s).+1 package had failing tests:.+",
-		},
-		{
-			name: "all tests (tagged and non-tagged) are run if 'all' is specified as the tag",
+			name: "only tagged tests are run if all is specified as tag",
 			filesToCreate: []gofiles.GoFileSpec{
 				{
 					RelPath: "foo_test.go",
@@ -520,6 +489,89 @@ func TestRun(t *testing.T) {
 			args: []string{
 				"--tags", "all",
 			},
+			wantMatch: func(currCaseTmpDir string) string {
+				return `(?s)` +
+					`--- FAIL: TestBar (.+)\n.+bar_test.go:[0-9]+: barFail.+FAIL\t` + pkgName(t, currCaseTmpDir) + `/bar\s+[0-9.]+s.+` +
+					`--- FAIL: TestBaz (.+)\n.+baz_test.go:[0-9]+: bazFail.+FAIL\t` + pkgName(t, currCaseTmpDir) + `/baz\s+[0-9.]+s.+`
+			},
+			wantError: "(?s).+2 packages had failing tests:.+",
+		},
+		{
+			name: "tags specified with uppercase letters works",
+			filesToCreate: []gofiles.GoFileSpec{
+				{
+					RelPath: "foo_test.go",
+					Src: `package foo
+					import "testing"
+					func TestFoo(t *testing.T) {
+						t.Errorf("fooFail")
+					}`,
+				},
+				{
+					RelPath: "bar/bar_test.go",
+					Src: `package bar
+					import "testing"
+					func TestBar(t *testing.T) {
+						t.Errorf("barFail")
+					}`,
+				},
+			},
+			config: unindent(`tags:
+					  Bar:
+					    paths:
+					      - "bar"
+					exclude:
+					  paths:
+					    - "vendor"
+					`),
+			args: []string{
+				"--tags", "Bar",
+			},
+			wantMatch: func(currCaseTmpDir string) string {
+				return `(?s)` +
+					`--- FAIL: TestBar (.+)\n.+bar_test.go:[0-9]+: barFail.+FAIL\t` + pkgName(t, currCaseTmpDir) + `/bar\t[0-9.]+s.+`
+			},
+			wantError: "(?s).+1 package had failing tests:.+",
+		},
+		{
+			name: "all tests (tagged and non-tagged) are run if tags are not specified",
+			filesToCreate: []gofiles.GoFileSpec{
+				{
+					RelPath: "foo_test.go",
+					Src: `package foo
+					import "testing"
+					func TestFoo(t *testing.T) {
+						t.Errorf("fooFail")
+					}`,
+				},
+				{
+					RelPath: "bar/bar_test.go",
+					Src: `package bar
+					import "testing"
+					func TestBar(t *testing.T) {
+						t.Errorf("barFail")
+					}`,
+				},
+				{
+					RelPath: "baz/baz_test.go",
+					Src: `package baz
+					import "testing"
+					func TestBaz(t *testing.T) {
+						t.Errorf("bazFail")
+					}`,
+				},
+			},
+			config: unindent(`tags:
+					  bar:
+					    paths:
+					      - "bar"
+					  baz:
+					    paths:
+					      - "baz"
+					exclude:
+					  paths:
+					    - "vendor"
+					`),
 			wantMatch: func(currCaseTmpDir string) string {
 				return `(?s)` +
 					`--- FAIL: TestFoo (.+)\n.+foo_test.go:[0-9]+: fooFail.+FAIL\t` + pkgName(t, currCaseTmpDir) + `\s+[0-9.]+s.+` +

--- a/apps/gunit/params/params.go
+++ b/apps/gunit/params/params.go
@@ -23,7 +23,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-const AllTagName = "all"
+const (
+	AllTagName  = "all"
+	NoneTagName = "none"
+)
 
 type GUnit struct {
 	// Tags group tests into different sets. The key is the name of the tag and the value is a matcher.NamesPathsCfg
@@ -50,8 +53,9 @@ func (p *GUnit) Validate() error {
 		}
 		seenTagNames[normalized] = struct{}{}
 
-		if normalized == AllTagName {
-			return errors.Errorf(`"all" is a reserved name that cannot be used as a tag name`)
+		switch normalized {
+		case AllTagName, NoneTagName:
+			return errors.Errorf("%q is a reserved name that cannot be used as a tag name", normalized)
 		}
 	}
 


### PR DESCRIPTION
Update the mental model and behavior of test tags.

* Running test task  without specifying any tags will now always run
  all tests (previously, this would only run untagged tests)
* Running test task with "--tags=all" will now run union of all tagged
  tests (previously, this would run all tagged and untagged tests)
* Running test task with "--tags=none" will now run only the untagged
  tests (this option did not previously exist and was the behavior when
  no tags were specified)

This change also makes it so that the "verify" task will run all tests
rather than just untagged tests.