### PR TITLE
Add more detailed output for github-wiki task

### DIFF
--- a/cmd/githubwiki/githubwiki.go
+++ b/cmd/githubwiki/githubwiki.go
@@ -72,7 +72,7 @@ func (g git) exec(args ...string) (string, error) {
 	cmd.Dir = string(g)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("%v failed: %v", cmd.Args, err)
+		return "", fmt.Errorf("%v failed\nError: %v\nOutput: %s", cmd.Args, err, string(output))
 	}
 	return strings.TrimSpace(string(output)), nil
 }


### PR DESCRIPTION
Print output of git command in addition to error in error output.