### PR TITLE
Checkpath os-specific logic so godel can build on windows.

### DIFF
--- a/cmd/checkpath/checkpath.go
+++ b/cmd/checkpath/checkpath.go
@@ -23,7 +23,6 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"syscall"
 
 	"github.com/pkg/errors"
 	"github.com/termie/go-shutil"
@@ -167,31 +166,6 @@ func checkForCfgFile(name string) string {
 		return cfgFile
 	}
 	return ""
-}
-
-func pathsOnSameDevice(p1, p2 string) bool {
-	id1, ok := getDeviceID(p1)
-	if !ok {
-		return false
-	}
-	id2, ok := getDeviceID(p2)
-	if !ok {
-		return false
-	}
-	return id1 == id2
-}
-
-func getDeviceID(p string) (interface{}, bool) {
-	fi, err := os.Stat(p)
-	if err != nil {
-		return 0, false
-	}
-	s := fi.Sys()
-	switch s := s.(type) {
-	case *syscall.Stat_t:
-		return s.Dev, true
-	}
-	return 0, false
 }
 
 func gitRepoRootPath(dir string) (string, error) {

--- a/cmd/checkpath/checkpath_unix.go
+++ b/cmd/checkpath/checkpath_unix.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux darwin
+// +build !windows
 
 package checkpath
 

--- a/cmd/checkpath/checkpath_unix.go
+++ b/cmd/checkpath/checkpath_unix.go
@@ -1,0 +1,33 @@
+// +build linux darwin
+
+package checkpath
+
+import (
+	"os"
+	"syscall"
+)
+
+func pathsOnSameDevice(p1, p2 string) bool {
+	id1, ok := getDeviceID(p1)
+	if !ok {
+		return false
+	}
+	id2, ok := getDeviceID(p2)
+	if !ok {
+		return false
+	}
+	return id1 == id2
+}
+
+func getDeviceID(p string) (interface{}, bool) {
+	fi, err := os.Stat(p)
+	if err != nil {
+		return 0, false
+	}
+	s := fi.Sys()
+	switch s := s.(type) {
+	case *syscall.Stat_t:
+		return s.Dev, true
+	}
+	return 0, false
+}

--- a/cmd/checkpath/checkpath_unix.go
+++ b/cmd/checkpath/checkpath_unix.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build linux darwin
 
 package checkpath

--- a/cmd/checkpath/checkpath_windows.go
+++ b/cmd/checkpath/checkpath_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+
+package checkpath
+
+import "path/filepath"
+
+func pathsOnSameDevice(p1, p2 string) bool {
+	id1 := filepath.VolumeName(p1)
+	id2 := filepath.VolumeName(p2)
+	return id1 == id2
+}

--- a/cmd/checkpath/checkpath_windows.go
+++ b/cmd/checkpath/checkpath_windows.go
@@ -1,8 +1,24 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build windows
 
 package checkpath
 
-import "path/filepath"
+import (
+	"path/filepath"
+)
 
 func pathsOnSameDevice(p1, p2 string) bool {
 	id1 := filepath.VolumeName(p1)

--- a/cmd/checkpath/checkpath_windows.go
+++ b/cmd/checkpath/checkpath_windows.go
@@ -21,7 +21,5 @@ import (
 )
 
 func pathsOnSameDevice(p1, p2 string) bool {
-	id1 := filepath.VolumeName(p1)
-	id2 := filepath.VolumeName(p2)
-	return id1 == id2
+	return filepath.VolumeName(p1) == filepath.VolumeName(p2)
 }


### PR DESCRIPTION
Fighting with running Godel on win10+VSCode without wanting to shiv myself; still need to write up godelw.ps1 and how to generate it, but this was the only chunk of os-specific code I found in build, so at least we can build under GOOS=windows, so it's a step in the right direction.