### PR TITLE
Add "docker" subommand to "artifacts" task

### DIFF
--- a/apps/distgo/cmd/artifacts/artifacts.go
+++ b/apps/distgo/cmd/artifacts/artifacts.go
@@ -15,6 +15,7 @@
 package artifacts
 
 import (
+	"fmt"
 	"path/filepath"
 	"strconv"
 
@@ -24,6 +25,19 @@ import (
 	"github.com/palantir/godel/apps/distgo/params"
 	"github.com/palantir/godel/apps/distgo/pkg/osarch"
 )
+
+// DockerArtifacts returns a map from product name to a slice that contains all of the Docker repository:tag labels
+// defined for the products.
+func DockerArtifacts(buildSpecsWithDeps []params.ProductBuildSpecWithDeps) map[string][]string {
+	output := make(map[string][]string)
+	for _, spec := range buildSpecsWithDeps {
+		for _, currImage := range spec.Spec.DockerImages {
+			imageName := fmt.Sprint(currImage.Repository, ":", currImage.Tag)
+			output[spec.Spec.ProductName] = append(output[spec.Spec.ProductName], imageName)
+		}
+	}
+	return output
+}
 
 // DistArtifacts returns a map from product name to OrderedStringSliceMap, where the values of the OrderedStringSliceMap
 // contains the mapping from the String representation of the index of the dist type ("0", "1", etc.) to the paths for

--- a/apps/distgo/cmd/artifacts/cmd.go
+++ b/apps/distgo/cmd/artifacts/cmd.go
@@ -49,6 +49,7 @@ func Command() cli.Command {
 		Subcommands: []cli.Command{
 			buildArtifactsCommand("build", "Print the paths to the build artifacts for products"),
 			artifactsCommand("dist", "Print the paths to the distribution artifacts for products", distArtifactsAction),
+			artifactsCommand("docker", "Print the labels for the Docker tags for products", dockerArtifactsAction),
 		},
 	}
 }
@@ -119,4 +120,14 @@ func buildArtifactsAction(ctx cli.Context, specs []params.ProductBuildSpecWithDe
 
 func distArtifactsAction(ctx cli.Context, specs []params.ProductBuildSpecWithDeps, absPath bool) (map[string]OrderedStringSliceMap, error) {
 	return DistArtifacts(specs, absPath)
+}
+
+func dockerArtifactsAction(ctx cli.Context, specs []params.ProductBuildSpecWithDeps, absPath bool) (map[string]OrderedStringSliceMap, error) {
+	artifacts := make(map[string]OrderedStringSliceMap)
+	for k, v := range DockerArtifacts(specs) {
+		ordered := newOrderedStringSliceMap()
+		ordered.PutValues(k, v)
+		artifacts[k] = ordered
+	}
+	return artifacts, nil
 }

--- a/apps/distgo/cmd/docker/products.go
+++ b/apps/distgo/cmd/docker/products.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package docker
 
 import (

--- a/apps/distgo/cmd/docker/products_test.go
+++ b/apps/distgo/cmd/docker/products_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package docker
 
 import (


### PR DESCRIPTION
Add "docker" subcommand that prints all of the tags that will be
created for a product.

Fixes #219