### PR TITLE
Fix output of 'verify' task

### DIFF
--- a/framework/builtintasks/verify.go
+++ b/framework/builtintasks/verify.go
@@ -122,7 +122,8 @@ func VerifyTask(tasks []godellauncher.Task) godellauncher.Task {
 					for _, check := range failedChecks {
 						msgParts = append(msgParts, "\t"+check)
 					}
-					return fmt.Errorf(strings.Join(msgParts, "\n"))
+					fmt.Fprintln(stdout, strings.Join(msgParts, "\n"))
+					return fmt.Errorf("")
 				}
 				return nil
 			}


### PR DESCRIPTION
Print error output to stdout and return error with empty content
so that output is not prefaced with "Error: ".