### PR TITLE
Fix minor godelgetter issues

### DIFF
--- a/godelgetter/download_test.go
+++ b/godelgetter/download_test.go
@@ -91,6 +91,57 @@ func TestDownloadIntoDirectory(t *testing.T) {
 	}
 }
 
+func TestDownloadSameFileOK(t *testing.T) {
+	tmpDir, cleanup, err := dirs.TempDir("", "")
+	require.NoError(t, err)
+	defer cleanup()
+
+	testFile := path.Join(tmpDir, "test.txt")
+	const content = "test content"
+	err = ioutil.WriteFile(testFile, []byte(content), 0644)
+	require.NoError(t, err)
+
+	_, err = godelgetter.DownloadIntoDirectory(godelgetter.NewPkgSrc(testFile, ""), tmpDir, ioutil.Discard)
+	require.NoError(t, err)
+
+	gotContent, err := ioutil.ReadFile(testFile)
+	require.NoError(t, err)
+
+	assert.Equal(t, content, string(gotContent))
+}
+
+func TestFailedReaderDoesNotOverwriteDestinationFile(t *testing.T) {
+	tmpDir, cleanup, err := dirs.TempDir("", "")
+	require.NoError(t, err)
+	defer cleanup()
+
+	const fileName = "test.txt"
+
+	srcDir := path.Join(tmpDir, "src")
+	err = os.MkdirAll(srcDir, 0755)
+	require.NoError(t, err)
+
+	dstDir := path.Join(tmpDir, "dst")
+	err = os.MkdirAll(dstDir, 0755)
+	require.NoError(t, err)
+
+	// write content in destination file
+	dstFile := path.Join(dstDir, fileName)
+	const content = "destination content"
+	err = ioutil.WriteFile(dstFile, []byte(content), 0644)
+	require.NoError(t, err)
+
+	srcFile := path.Join(srcDir, fileName)
+	_, err = godelgetter.DownloadIntoDirectory(godelgetter.NewPkgSrc(srcFile, ""), dstDir, os.Stdout)
+	// download operation should fail
+	assert.EqualError(t, err, fmt.Sprintf("%s does not exist", srcFile))
+
+	// destination file should still exist (should not have been truncated by download with failed source reader)
+	gotContent, err := ioutil.ReadFile(dstFile)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(gotContent))
+}
+
 func writeSimpleTestTgz(t *testing.T, filePath string) {
 	tmpDir, cleanup, err := dirs.TempDir("", "")
 	defer cleanup()


### PR DESCRIPTION
Ensure that destination file is not truncated if source reader
cannot be created and improve logic in interface.