### PR TITLE
Add pluginapitester package

### DIFF
--- a/framework/internal/pathsinternal/plugins.go
+++ b/framework/internal/pathsinternal/plugins.go
@@ -1,0 +1,46 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pathsinternal
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/palantir/pkg/specdir"
+	"github.com/pkg/errors"
+
+	"github.com/palantir/godel/framework/artifactresolver"
+	"github.com/palantir/godel/framework/builtintasks/installupdate/layout"
+)
+
+func PluginPath(pluginDir string, locator artifactresolver.Locator) string {
+	return path.Join(pluginDir, PluginFileName(locator))
+}
+
+func PluginFileName(locator artifactresolver.Locator) string {
+	return fmt.Sprintf("%s-%s-%s", locator.Group, locator.Product, locator.Version)
+}
+
+func ConfigProviderFileName(locator artifactresolver.Locator) string {
+	return PluginFileName(locator) + ".yml"
+}
+
+func ResourceDirs() (pluginsDir string, assetsDir string, downloadsDir string, rErr error) {
+	gödelHomeSpecDir, err := layout.GodelHomeSpecDir(specdir.Create)
+	if err != nil {
+		return "", "", "", errors.Wrapf(err, "failed to create gödel home directory")
+	}
+	return gödelHomeSpecDir.Path(layout.PluginsDir), gödelHomeSpecDir.Path(layout.AssetsDir), gödelHomeSpecDir.Path(layout.DownloadsDir), nil
+}

--- a/framework/pluginapitester/assettester.go
+++ b/framework/pluginapitester/assettester.go
@@ -1,0 +1,67 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pluginapitester provides functions that simulate invoking a plugin from gödel. Can be used to test plugin
+// implementations in plugin projects.
+package pluginapitester
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/pkg/errors"
+
+	"github.com/palantir/godel/framework/artifactresolver"
+	"github.com/palantir/godel/framework/godellauncher"
+	"github.com/palantir/godel/framework/internal/pathsinternal"
+	"github.com/palantir/godel/framework/plugins"
+)
+
+// RunAsset resolves the plugin with the provided locator and then runs it with the specified assets using RunPlugin.
+// Can be used to test assets for which the plugin is published separately.
+func RunAsset(
+	pluginLocator artifactresolver.LocatorWithResolverParam,
+	assetPaths []string,
+	taskName string,
+	args []string,
+	projectDir string,
+	debug bool,
+	stdout io.Writer) (cleanup func(), rErr error) {
+
+	pluginPath, err := resolvePlugin(pluginLocator)
+	if err != nil {
+		return func() {}, errors.Wrapf(err, "failed to resolve plugin")
+	}
+	return RunPlugin(pluginPath, assetPaths, taskName, args, projectDir, debug, stdout)
+}
+
+// resolvePlugin resolves the plugin with the provided locator and returns the path to the resolved plugin.
+func resolvePlugin(pluginLocator artifactresolver.LocatorWithResolverParam) (string, error) {
+	buf := &bytes.Buffer{}
+	if _, err := plugins.LoadPluginsTasks(godellauncher.PluginsParam{
+		Plugins: []godellauncher.SinglePluginParam{
+			{
+				LocatorWithResolverParam: pluginLocator,
+			},
+		},
+	}, buf); err != nil {
+		return "", errors.Wrapf(err, "failed to load plugin task. Output: %s", buf.String())
+	}
+
+	pluginsDir, _, _, err := pathsinternal.ResourceDirs()
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to determine plugin directory")
+	}
+	return pathsinternal.PluginPath(pluginsDir, pluginLocator.LocatorWithChecksums.Locator), nil
+}

--- a/framework/pluginapitester/plugintester.go
+++ b/framework/pluginapitester/plugintester.go
@@ -1,0 +1,92 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pluginapitester provides functions that simulate invoking a plugin from gödel. Can be used to test plugin
+// implementations in plugin projects.
+package pluginapitester
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/palantir/godel/framework/godellauncher"
+	"github.com/palantir/godel/framework/pluginapi"
+)
+
+// RunPlugin runs a plugin with the specified arguments. The plugin is loaded in the same manner that it would be for
+// gödel itself. RunPlugin is equivalent to calling "./godelw [taskName] [args]" where "godelw" is in "projectDir". Note
+// that this call does not change the working directory, so any arguments that take relative paths should take that into
+// account. If "debug" is true, then it is the equivalent of calling "./godelw --debug [taskName] [args]". If the
+// project directory does not contain a file named "godelw", this function creates the path. The returned "cleanup"
+// function removes the "godelw" file if it was created by this function and is suitable to defer.
+func RunPlugin(
+	pluginPath string,
+	assets []string,
+	taskName string,
+	args []string,
+	projectDir string,
+	debug bool,
+	stdout io.Writer) (cleanup func(), rErr error) {
+
+	cleanup = func() {}
+	info, err := pluginapi.InfoFromPlugin(pluginPath)
+	if err != nil {
+		return cleanup, err
+	}
+	taskMap := make(map[string]godellauncher.Task)
+	var taskNames []string
+	for _, task := range info.Tasks(pluginPath, assets) {
+		taskMap[task.Name] = task
+		taskNames = append(taskNames, task.Name)
+	}
+	task, ok := taskMap[taskName]
+	if !ok {
+		return cleanup, errors.Errorf("task %s does not exist. Valid tasks: %v", taskName, taskNames)
+	}
+
+	globalConfig := godellauncher.GlobalConfig{
+		Task:     taskName,
+		TaskArgs: args,
+		Debug:    debug,
+	}
+	if projectDir != "" {
+		if !filepath.IsAbs(projectDir) {
+			wd, err := os.Getwd()
+			if err != nil {
+				return cleanup, errors.Wrapf(err, "failed to determine working directory")
+			}
+			projectDir = path.Join(wd, projectDir)
+		}
+
+		godelwPath := path.Join(projectDir, "godelw")
+		if _, err := os.Stat(godelwPath); os.IsNotExist(err) {
+			if err := ioutil.WriteFile(godelwPath, nil, 0644); err != nil {
+				return cleanup, errors.Wrapf(err, "failed to create temporary godelw file")
+			}
+			cleanup = func() {
+				if err := os.Remove(godelwPath); err != nil {
+					fmt.Println(errors.Wrapf(err, "failed to remove temporary godelw file"))
+				}
+			}
+		}
+		globalConfig.Wrapper = path.Join(projectDir, "godelw")
+	}
+	return cleanup, task.Run(globalConfig, stdout)
+}

--- a/framework/plugins/configprovider.go
+++ b/framework/plugins/configprovider.go
@@ -30,6 +30,7 @@ import (
 	"github.com/palantir/godel/framework/artifactresolver"
 	"github.com/palantir/godel/framework/builtintasks/installupdate/layout"
 	"github.com/palantir/godel/framework/godellauncher"
+	"github.com/palantir/godel/framework/internal/pathsinternal"
 )
 
 // LoadProvidedConfigurations returns all of the godellauncher.GodelConfig configurations provided by the specified
@@ -116,10 +117,10 @@ func resolveAndVerifyConfigProvider(
 	stdout io.Writer) (currLocator artifactresolver.Locator, ok bool) {
 
 	currLocator = currArtifact.LocatorWithChecksums.Locator
-	currDstPath := path.Join(dstBaseDir, configFileName(currLocator))
+	currDstPath := path.Join(dstBaseDir, pathsinternal.ConfigProviderFileName(currLocator))
 
 	if _, err := os.Stat(currDstPath); os.IsNotExist(err) {
-		downloadDstPath := path.Join(downloadsDir, configFileName(currLocator))
+		downloadDstPath := path.Join(downloadsDir, pathsinternal.ConfigProviderFileName(currLocator))
 		if err := artifactresolver.ResolveArtifact(currArtifact, defaultResolvers, osarch.Current(), downloadDstPath, artifactresolver.SHA256ChecksumFile, stdout); err != nil {
 			artifactErrors[currLocator] = err
 			return currLocator, false
@@ -164,7 +165,7 @@ func resolveAndVerifyConfigProvider(
 }
 
 func readConfigFromProvider(locator artifactresolver.Locator, configsDir string) (godellauncher.TasksConfig, error) {
-	cfgPath := path.Join(configsDir, configFileName(locator))
+	cfgPath := path.Join(configsDir, pathsinternal.ConfigProviderFileName(locator))
 
 	cfgBytes, err := ioutil.ReadFile(cfgPath)
 	if err != nil {
@@ -176,8 +177,4 @@ func readConfigFromProvider(locator artifactresolver.Locator, configsDir string)
 		return godellauncher.TasksConfig{}, errors.Wrapf(err, "failed to unmarshal %q as godellauncher.GodelConfig", string(cfgBytes))
 	}
 	return tasksCfg, nil
-}
-
-func configFileName(locator artifactresolver.Locator) string {
-	return pluginFileName(locator) + ".yml"
 }

--- a/framework/plugins/plugin_test.go
+++ b/framework/plugins/plugin_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/palantir/godel/apps/distgo/pkg/osarch"
 	"github.com/palantir/godel/framework/artifactresolver"
 	"github.com/palantir/godel/framework/godellauncher"
+	"github.com/palantir/godel/framework/internal/pathsinternal"
 	"github.com/palantir/godel/framework/pluginapi"
 )
 
@@ -53,7 +54,7 @@ func TestInfoFromResolved(t *testing.T) {
 	err = ioutil.WriteFile(pluginFile, []byte(fmt.Sprintf(pluginScriptTmpl, pluginName)), 0755)
 	require.NoError(t, err)
 
-	gotInfo, err := pluginapi.InfoFromPlugin(path.Join(tmpDir, pluginFileName(artifactresolver.Locator{
+	gotInfo, err := pluginapi.InfoFromPlugin(path.Join(tmpDir, pathsinternal.PluginFileName(artifactresolver.Locator{
 		Group:   "com.palantir",
 		Product: pluginName,
 		Version: "1.0.0",
@@ -83,7 +84,7 @@ exit 1
 `), 0755)
 	require.NoError(t, err)
 
-	_, err = pluginapi.InfoFromPlugin(path.Join(tmpDir, pluginFileName(artifactresolver.Locator{
+	_, err = pluginapi.InfoFromPlugin(path.Join(tmpDir, pathsinternal.PluginFileName(artifactresolver.Locator{
 		Group:   "com.palantir",
 		Product: pluginName,
 		Version: "1.0.0",


### PR DESCRIPTION
Adds new pluginapitester package to allow plugin and asset
projects test functionality. Also refactors some APIs to
use internal packages to allow for this.