### PR TITLE
Set stderr of plugin tasks to write to provided writer

### DIFF
--- a/framework/pluginapi/taskinfo.go
+++ b/framework/pluginapi/taskinfo.go
@@ -179,7 +179,7 @@ func (ti taskInfoImpl) toTask(pluginExecPath, cfgFileName string, assets []strin
 			cmdArgs = append(cmdArgs, global.TaskArgs...)
 			cmd := exec.Command(pluginExecPath, cmdArgs...)
 			cmd.Stdout = stdout
-			cmd.Stderr = os.Stderr
+			cmd.Stderr = stdout
 			cmd.Stdin = os.Stdin
 			if err := cmd.Run(); err != nil {
 				if _, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
Ensures that all plugin output is captured properly.