### PR TITLE
Change VerifyOptionsTaskFlags to be additive

### DIFF
--- a/framework/pluginapi/verifyopts.go
+++ b/framework/pluginapi/verifyopts.go
@@ -51,15 +51,13 @@ func (f verifyOptsFunc) apply(impl *verifyOptionsImpl) {
 
 func VerifyOptionsTaskFlags(flags ...VerifyFlag) VerifyOptionsParam {
 	return verifyOptsFunc(func(impl *verifyOptionsImpl) {
-		var verifyFlagImpls []verifyFlagImpl
 		for _, f := range flags {
-			verifyFlagImpls = append(verifyFlagImpls, verifyFlagImpl{
+			impl.VerifyTaskFlagsVar = append(impl.VerifyTaskFlagsVar, verifyFlagImpl{
 				NameVar:        f.Name(),
 				DescriptionVar: f.Description(),
 				TypeVar:        f.Type(),
 			})
 		}
-		impl.VerifyTaskFlagsVar = verifyFlagImpls
 	})
 }
 


### PR DESCRIPTION
Make the task flag option additive rather than having it set
the variable. Reduces a class of bugs where verify options
are specifeid as multiple options parameters rather than as
a single parameter with multiple flags.