### PR TITLE
Fix checksum logic for installation

### DIFF
--- a/framework/builtintasks/installupdate/update.go
+++ b/framework/builtintasks/installupdate/update.go
@@ -65,7 +65,7 @@ func Update(projectDirPath string, srcPkg godelgetter.PkgSrc, stdout io.Writer) 
 
 // InstallVersion installs the specified version of gödel in the provided project directory. If targetVersion is the
 // empty string, the latest version is determined and used.
-func InstallVersion(projectDir, targetVersion string, cacheValidDuration time.Duration, newInstall bool, stdout io.Writer) error {
+func InstallVersion(projectDir, targetVersion, wantChecksum string, cacheValidDuration time.Duration, newInstall bool, stdout io.Writer) error {
 	if targetVersion == "" {
 		version, err := latestGodelVersion(cacheValidDuration)
 		if err != nil {
@@ -73,7 +73,7 @@ func InstallVersion(projectDir, targetVersion string, cacheValidDuration time.Du
 		}
 		targetVersion = version
 	}
-	pkgSrc, err := pkgSrcForVersion(targetVersion)
+	pkgSrc, err := pkgSrcForVersion(targetVersion, wantChecksum)
 	if err != nil {
 		return err
 	}
@@ -88,9 +88,9 @@ func InstallVersion(projectDir, targetVersion string, cacheValidDuration time.Du
 		return err
 	}
 
-	// update godel.properties with checksum
-	if checksum := pkgSrc.Checksum(); checksum != "" {
-		if err := setGodelPropertyKey(projectDir, propertiesChecksumKey, checksum); err != nil {
+	// update godel.properties with checksum if provided (if this point was reached, checksum was verified)
+	if wantChecksum != "" {
+		if err := setGodelPropertyKey(projectDir, propertiesChecksumKey, wantChecksum); err != nil {
 			return err
 		}
 	}
@@ -99,17 +99,16 @@ func InstallVersion(projectDir, targetVersion string, cacheValidDuration time.Du
 
 // pkgSrcForVersion returns a package source for the provided version. If the distribution for the provided version has
 // been downloaded locally, the package source uses the filesystem path. Otherwise, the package source specifies the
-// Bintray download URL.
-func pkgSrcForVersion(version string) (godelgetter.PkgSrc, error) {
+// Bintray download URL. Sets the provided checksum as the expected checksum for the package (blank means no checksum).
+func pkgSrcForVersion(version, wantChecksum string) (godelgetter.PkgSrc, error) {
 	if version == "" {
 		return nil, errors.Errorf("version for package must be specified")
 	}
-	pkgPath, checksum, err := downloadedTGZForVersion(version)
+	pkgPath, _, err := downloadedTGZForVersion(version)
 	if err != nil {
 		pkgPath = fmt.Sprintf("https://palantir.bintray.com/releases/com/palantir/godel/godel/%s/godel-%s.tgz", version, version)
-		checksum = ""
 	}
-	return godelgetter.NewPkgSrc(pkgPath, checksum), nil
+	return godelgetter.NewPkgSrc(pkgPath, wantChecksum), nil
 }
 
 // downloadedTGZForVersion returns the path and checksum for the downloaded TGZ for the specified version. Returns an

--- a/framework/builtintasks/update.go
+++ b/framework/builtintasks/update.go
@@ -29,6 +29,7 @@ func UpdateTask(wrapperPath string) godellauncher.Task {
 	var (
 		syncFlag          bool
 		versionFlag       string
+		checksumFlag      string
 		cacheDurationFlag time.Duration
 	)
 
@@ -49,11 +50,12 @@ func UpdateTask(wrapperPath string) godellauncher.Task {
 				}
 				return installupdate.Update(projectDir, pkgSrc, cmd.OutOrStdout())
 			}
-			return installupdate.InstallVersion(projectDir, versionFlag, cacheDurationFlag, false, cmd.OutOrStdout())
+			return installupdate.InstallVersion(projectDir, versionFlag, checksumFlag, cacheDurationFlag, false, cmd.OutOrStdout())
 		},
 	}
-	cmd.Flags().BoolVar(&syncFlag, "sync", false, "use version and checksum specified in godel.properties")
+	cmd.Flags().BoolVar(&syncFlag, "sync", false, "use version and checksum specified in godel.properties (if true, all other flags are ignored)")
 	cmd.Flags().StringVar(&versionFlag, "version", "", "version to update (if blank, uses latest version)")
+	cmd.Flags().StringVar(&checksumFlag, "checksum", "", "expected checksum for package")
 	cmd.Flags().DurationVar(&cacheDurationFlag, "cache-duration", time.Hour, "duration for which cache entries should be considered valid")
 
 	return godellauncher.CobraCLITask(cmd)

--- a/godelinit/root.go
+++ b/godelinit/root.go
@@ -27,6 +27,7 @@ import (
 func rootCmd() *cobra.Command {
 	var (
 		versionFlag       string
+		checksumFlag      string
 		cacheDurationFlag time.Duration
 	)
 
@@ -41,11 +42,12 @@ to the project. If a specific version of godel is desired, it can be specified u
 			if err != nil {
 				return errors.Wrapf(err, "failed to determine working directory")
 			}
-			return installupdate.InstallVersion(wd, versionFlag, cacheDurationFlag, true, cmd.OutOrStdout())
+			return installupdate.InstallVersion(wd, versionFlag, checksumFlag, cacheDurationFlag, true, cmd.OutOrStdout())
 		},
 	}
 
 	cmd.Flags().StringVar(&versionFlag, "version", "", "version to install (if unspecified, latest is used)")
+	cmd.Flags().StringVar(&checksumFlag, "checksum", "", "expected checksum for package")
 	cmd.Flags().DurationVar(&cacheDurationFlag, "cache-duration", time.Hour, "duration for which cache entries should be considered valid")
 	return cmd
 }


### PR DESCRIPTION
Fix bug where, if an installation package source was local, the
checksum of the local file was used as the expected checksum.
Checksums are now compared against expectation instead. Also adds
a --checksum flag to godelinit and "update" task which allows the
desired checksum to be specified.