### PR TITLE
Improve error output for config upgrade failures.

### DIFF
--- a/framework/builtintasks/upgradeconfig.go
+++ b/framework/builtintasks/upgradeconfig.go
@@ -75,7 +75,7 @@ func UpgradeConfigTask(upgradeTasks []godellauncher.UpgradeConfigTask) godellaun
 				for _, upgradeTask := range upgradeTasks {
 					changed, upgradedCfgBytes, err := upgradeConfigFile(upgradeTask, global, configDirPath, dryRunFlagVal, stdout)
 					if err != nil {
-						failedUpgrades = append(failedUpgrades, fmt.Sprintf("%s: %v", path.Join(configDirPath, upgradeTask.ConfigFile), err))
+						failedUpgrades = append(failedUpgrades, upgradeError(projectDir, path.Join(configDirPath, upgradeTask.ConfigFile), err))
 						continue
 					}
 					if !changed {
@@ -176,4 +176,14 @@ func backupConfigFile(cfgFilePath string, dryRun bool, stdout io.Writer) error {
 		}
 	}
 	return nil
+}
+
+func upgradeError(projectDir, configFilePath string, upgradeErr error) string {
+	// convert path to relative path if it is absolute. No-op if conversion to absolute path fails.
+	if filepath.IsAbs(configFilePath) {
+		if relPath, err := filepath.Rel(projectDir, configFilePath); err == nil {
+			configFilePath = relPath
+		}
+	}
+	return fmt.Sprintf("%s: %v", configFilePath, upgradeErr)
 }

--- a/framework/builtintasks/upgradelegacyconfig.go
+++ b/framework/builtintasks/upgradelegacyconfig.go
@@ -90,7 +90,7 @@ func UpgradeLegacyConfigTask(upgradeTasks []godellauncher.UpgradeConfigTask) god
 						continue
 					}
 					if err := upgradeLegacyConfig(upgradeTask, cfgDirPath, global, dryRunFlagVal, printContentFlagVal, stdout); err != nil {
-						failedUpgrades = append(failedUpgrades, fmt.Sprintf("%s: %v", path.Join(cfgDirPath, upgradeTask.ConfigFile), err))
+						failedUpgrades = append(failedUpgrades, upgradeError(projectDir, path.Join(cfgDirPath, upgradeTask.ConfigFile), err))
 						continue
 					}
 				}

--- a/framework/pluginapi/upgradeconfigtaskinfo.go
+++ b/framework/pluginapi/upgradeconfigtaskinfo.go
@@ -122,6 +122,10 @@ func (ti upgradeConfigTaskInfoImpl) toTask(pluginExecPath, cfgFileName string, a
 					output = strings.TrimPrefix(output, "Error: ")
 					output = strings.TrimSuffix(output, "\n")
 				}
+				if _, ok := err.(*exec.ExitError); ok {
+					// if error was an exit error, don't bother wrapping because it's probably just "exit 1"
+					return nil, errors.Errorf(output)
+				}
 				return nil, errors.Wrapf(err, output)
 			}
 


### PR DESCRIPTION
Output config upgrade errors using relative paths and remove
trailing ": exit 1" outputs.