### PR TITLE
Add functions to versionedconfig package

### DIFF
--- a/pkg/gocd_imports.json
+++ b/pkg/gocd_imports.json
@@ -51,7 +51,8 @@
                 "github.com/palantir/godel/pkg/dirchecksum_test",
                 "github.com/palantir/godel/pkg/osarch_test",
                 "github.com/palantir/godel/pkg/products_test",
-                "github.com/palantir/godel/pkg/v2/products_test"
+                "github.com/palantir/godel/pkg/v2/products_test",
+                "github.com/palantir/godel/pkg/versionedconfig_test"
             ]
         },
         {
@@ -62,7 +63,8 @@
                 "github.com/palantir/godel/pkg/dirchecksum_test",
                 "github.com/palantir/godel/pkg/osarch_test",
                 "github.com/palantir/godel/pkg/products_test",
-                "github.com/palantir/godel/pkg/v2/products_test"
+                "github.com/palantir/godel/pkg/v2/products_test",
+                "github.com/palantir/godel/pkg/versionedconfig_test"
             ]
         }
     ]

--- a/pkg/versionedconfig/legacy.go
+++ b/pkg/versionedconfig/legacy.go
@@ -1,0 +1,33 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versionedconfig
+
+import (
+	"gopkg.in/yaml.v2"
+)
+
+// ConfigWithLegacy is a struct with a "legacy" YAML field that stores a boolean that indicates whether or not the
+// configuration is "legacy" configuration.
+type ConfigWithLegacy struct {
+	Legacy bool `yaml:"legacy-config"`
+}
+
+func IsLegacyConfig(cfgBytes []byte) bool {
+	var cfg ConfigWithLegacy
+	if err := yaml.Unmarshal(cfgBytes, &cfg); err != nil {
+		return false
+	}
+	return cfg.Legacy
+}

--- a/pkg/versionedconfig/unsupported.go
+++ b/pkg/versionedconfig/unsupported.go
@@ -1,0 +1,32 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versionedconfig
+
+import (
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+// ConfigNotSupported verifies that the provided bytes represent empty YAML. If the YAML is non-empty, return an error.
+func ConfigNotSupported(name string, cfgBytes []byte) ([]byte, error) {
+	var mapSlice yaml.MapSlice
+	if err := yaml.Unmarshal(cfgBytes, &mapSlice); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal %s configuration as yaml.MapSlice", name)
+	}
+	if len(mapSlice) != 0 {
+		return nil, errors.Errorf("%s does not currently support configuration", name)
+	}
+	return cfgBytes, nil
+}

--- a/pkg/versionedconfig/unsupported_test.go
+++ b/pkg/versionedconfig/unsupported_test.go
@@ -1,0 +1,70 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versionedconfig_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/palantir/godel/pkg/versionedconfig"
+)
+
+func TestConfigNotSupported(t *testing.T) {
+	for i, tc := range []struct {
+		name      string
+		cfgName   string
+		yaml      string
+		wantError string
+		wantBytes []byte
+	}{
+		{
+			"empty configuration valid",
+			"test",
+			``,
+			"",
+			[]byte{},
+		},
+		{
+			"comment-only configuration valid",
+			"test",
+			`
+# only a comment
+`,
+			"",
+			[]byte(`
+# only a comment
+`),
+		},
+		{
+			"non-empty configuration invalid",
+			"test",
+			`key: value
+`,
+			"test does not currently support configuration",
+			nil,
+		},
+	} {
+		got, err := versionedconfig.ConfigNotSupported(tc.cfgName, []byte(tc.yaml))
+		if tc.wantError != "" {
+			require.Error(t, err, "Case %d: %s", i, tc.name)
+			assert.EqualError(t, err, tc.wantError, "Case %d: %s", i, tc.name)
+		} else {
+			require.NoError(t, err, "Case %d: %s", i, tc.name)
+		}
+		assert.Equal(t, tc.wantBytes, got, "Case %d: %s", i, tc.name)
+	}
+}


### PR DESCRIPTION
Add functions for standardizing behavior for dealing with legacy
configuration and dealing with the case where configuration is not
currently supported.