### PR TITLE
Run upgrade-config tasks on update or godelinit

### DIFF
--- a/framework/builtintasks/installupdate/godelwcmds.go
+++ b/framework/builtintasks/installupdate/godelwcmds.go
@@ -1,0 +1,63 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installupdate
+
+import (
+	"io"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// RunUpgradeConfig runs the "upgrade--config" task by invoking "{{projectDir}}/godelw upgrade-config".
+func RunUpgradeConfig(projectDir string, stdout, stderr io.Writer) error {
+	godelw := path.Join(projectDir, "godelw")
+	cmd := exec.Command(godelw, "upgrade-config")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+// RunUpgradeLegacyConfig runs the "upgrade-legacy-config" task by invoking
+// "{{projectDir}}/godelw upgrade-legacy-config".
+func RunUpgradeLegacyConfig(projectDir string, stdout, stderr io.Writer) error {
+	godelw := path.Join(projectDir, "godelw")
+	cmd := exec.Command(godelw, "upgrade-legacy-config")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+// GodelVersion returns the Version returned by "{{projectDir}}/godelw version".
+func GodelVersion(projectDir string) (Version, error) {
+	godelw := path.Join(projectDir, "godelw")
+	cmd := exec.Command(godelw, "version")
+	output, err := cmd.Output()
+	if err != nil {
+		return Version{}, errors.Wrapf(err, "failed to execute command %v: %s", cmd.Args, string(output))
+	}
+	outputString := strings.TrimSpace(string(output))
+	parts := strings.Split(outputString, " ")
+	if len(parts) != 3 {
+		return Version{}, errors.Errorf(`expected output %s to have 3 parts when split by " ", but was %v`, outputString, parts)
+	}
+	v, err := NewVersion(parts[2])
+	if err != nil {
+		return Version{}, errors.Wrapf(err, "failed to create version from output")
+	}
+	return v, nil
+}

--- a/framework/builtintasks/installupdate/install.go
+++ b/framework/builtintasks/installupdate/install.go
@@ -109,7 +109,7 @@ func install(src godelgetter.PkgSrc, stdout io.Writer) (string, error) {
 }
 
 // getExecutableVersion gets the version of gödel contained in the provided root gödel directory. Invokes the executable
-// for the current platform with the "--version" flag and returns the version determined by that output.
+// for the current platform with the "version" task and returns the version determined by that output.
 func getExecutableVersion(gödelApp specdir.SpecDir) (string, error) {
 	executablePath := gödelApp.Path(layout.AppExecutable)
 	cmd := exec.Command(executablePath, "version")
@@ -123,6 +123,5 @@ func getExecutableVersion(gödelApp specdir.SpecDir) (string, error) {
 	if len(parts) != 3 {
 		return "", errors.Errorf(`expected output %s to have 3 parts when split by " ", but was %v`, outputString, parts)
 	}
-
 	return parts[2], nil
 }

--- a/framework/builtintasks/installupdate/versionparser.go
+++ b/framework/builtintasks/installupdate/versionparser.go
@@ -1,0 +1,212 @@
+// Copyright 2016 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installupdate
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+type Type int
+
+var unknown = Type(-1)
+
+const (
+	ReleaseCandidate Type = iota
+	ReleaseCandidateSnapshot
+	Release
+	ReleaseSnapshot
+	NonOrderable
+)
+
+func (t Type) String() string {
+	switch t {
+	case ReleaseCandidate:
+		return "ReleaseCandidate"
+	case ReleaseCandidateSnapshot:
+		return "ReleaseCandidateSnapshot"
+	case Release:
+		return "Release"
+	case ReleaseSnapshot:
+		return "ReleaseSnapshot"
+	case NonOrderable:
+		return "NonOrderable"
+	}
+	return strconv.Itoa(int(t))
+}
+
+var releaseRegexps = []*regexp.Regexp{
+	ReleaseCandidate:         regexp.MustCompile(`^([0-9]+)\.([0-9]+)\.([0-9])+-rc([0-9]+)$`),
+	ReleaseCandidateSnapshot: regexp.MustCompile(`^([0-9]+)\.([0-9]+)\.([0-9])+-rc([0-9]+)-([0-9]+)-g[a-f0-9]+$`),
+	Release:                  regexp.MustCompile(`^([0-9]+)\.([0-9]+)\.([0-9])+$`),
+	ReleaseSnapshot:          regexp.MustCompile(`^([0-9]+)\.([0-9]+)\.([0-9])+-([0-9]+)-g[a-f0-9]+$`),
+	NonOrderable:             regexp.MustCompile(`^([0-9]+)\.([0-9]+)\.([0-9])+(-[a-z0-9-]+)?(\.dirty)?$`),
+}
+
+type Version struct {
+	version string
+
+	// computed once on construction and stored
+	typ                      Type
+	majorVersionNum          int
+	minorVersionNum          int
+	patchVersionNum          int
+	firstSequenceVersionNum  *int
+	secondSequenceVersionNum *int
+}
+
+func (v Version) String() string {
+	return v.version
+}
+
+func (v Version) Type() Type {
+	return getType(v.version)
+}
+
+func (v Version) Orderable() bool {
+	typ := v.Type()
+	return typ >= ReleaseCandidate && typ < NonOrderable
+}
+
+func (v Version) Value() string {
+	return v.version
+}
+
+func (v Version) MajorVersionNum() int {
+	return v.majorVersionNum
+}
+
+func (v Version) MinorVersionNum() int {
+	return v.minorVersionNum
+}
+
+func (v Version) PatchVersionNum() int {
+	return v.patchVersionNum
+}
+
+func (v Version) FirstSequenceVersionNum() *int {
+	return v.firstSequenceVersionNum
+}
+
+func (v Version) SecondSequenceVersionNum() *int {
+	return v.secondSequenceVersionNum
+}
+
+func NewVersion(v string) (Version, error) {
+	typ := getType(v)
+	if typ == unknown {
+		return Version{}, fmt.Errorf("%s is not a valid SLS version", v)
+	}
+
+	matches := releaseRegexps[typ].FindStringSubmatch(v)
+
+	var firstSequenceVersionNum *int
+	if typ != NonOrderable && len(matches) > 4 {
+		n := mustAtoI(matches[4])
+		firstSequenceVersionNum = &n
+	}
+	var secondSequenceVersionNum *int
+	if typ != NonOrderable && len(matches) > 5 {
+		n := mustAtoI(matches[5])
+		secondSequenceVersionNum = &n
+	}
+
+	return Version{
+		version:                  v,
+		typ:                      typ,
+		majorVersionNum:          mustAtoI(matches[1]),
+		minorVersionNum:          mustAtoI(matches[2]),
+		patchVersionNum:          mustAtoI(matches[3]),
+		firstSequenceVersionNum:  firstSequenceVersionNum,
+		secondSequenceVersionNum: secondSequenceVersionNum,
+	}, nil
+}
+
+func getType(v string) Type {
+	for i, regExp := range releaseRegexps {
+		if regExp.MatchString(v) {
+			return Type(i)
+		}
+	}
+	return unknown
+}
+
+// CompareTo compares the receiver to the provided version. If either version is not orderable (as defined by the spec),
+// always returns -1 and false. If both versions are orderable, then returns -1 if the receiver is less than the
+// argument, 0 if they are equal and 1 if the receiver is greater than the argument. If both versions are orderable, the
+// second return value is always true.
+func (v Version) CompareTo(o Version) (int, bool) {
+	// if either input is not orderable, always return -1 and false
+	if !v.Orderable() || !o.Orderable() {
+		return -1, false
+	}
+
+	switch {
+	case v.MajorVersionNum() != o.MajorVersionNum():
+		return compareInts(v.MajorVersionNum(), o.MajorVersionNum()), true
+	case v.MinorVersionNum() != o.MinorVersionNum():
+		return compareInts(v.MinorVersionNum(), o.MinorVersionNum()), true
+	case v.PatchVersionNum() != o.PatchVersionNum():
+		return compareInts(v.PatchVersionNum(), o.PatchVersionNum()), true
+	case (v.Type() == ReleaseSnapshot && o.Type() == Release) || (v.Type() == Release && o.Type() == ReleaseSnapshot):
+		if v.Type() == ReleaseSnapshot {
+			return 1, true
+		}
+		return -1, true
+	case (v.Type() == Release && o.Type() == ReleaseCandidate) || (v.Type() == ReleaseCandidate && o.Type() == Release):
+		if v.Type() == Release {
+			return 1, true
+		}
+		return -1, true
+	case v.Type() == ReleaseSnapshot && o.Type() == ReleaseSnapshot:
+		return compareInts(*v.FirstSequenceVersionNum(), *o.FirstSequenceVersionNum()), true
+	case (v.Type() == ReleaseCandidate || v.Type() == ReleaseCandidateSnapshot) && (o.Type() == ReleaseCandidate || o.Type() == ReleaseCandidateSnapshot):
+		if cmp := compareInts(*v.FirstSequenceVersionNum(), *o.FirstSequenceVersionNum()); cmp != 0 {
+			return cmp, true
+		}
+
+		if v.Type() != o.Type() {
+			if v.Type() == ReleaseCandidateSnapshot {
+				return 1, true
+			}
+			return -1, true
+		}
+
+		if v.Type() == ReleaseCandidateSnapshot {
+			return compareInts(*v.SecondSequenceVersionNum(), *o.SecondSequenceVersionNum()), true
+		}
+	}
+	return 0, true
+}
+
+func compareInts(val, other int) int {
+	switch {
+	default:
+		return 0
+	case val < other:
+		return -1
+	case val > other:
+		return 1
+	}
+}
+
+func mustAtoI(in string) int {
+	out, err := strconv.Atoi(in)
+	if err != nil {
+		panic(fmt.Sprintf("invalid version string: %s must be parsable as an int", in))
+	}
+	return out
+}

--- a/framework/builtintasks/update.go
+++ b/framework/builtintasks/update.go
@@ -17,6 +17,7 @@ package builtintasks
 import (
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/palantir/godel/framework/builtintasks/installupdate"
@@ -25,11 +26,12 @@ import (
 
 func UpdateTask() godellauncher.Task {
 	var (
-		syncFlag          bool
-		versionFlag       string
-		checksumFlag      string
-		cacheDurationFlag time.Duration
-		globalCfg         godellauncher.GlobalConfig
+		syncFlag              bool
+		versionFlag           string
+		checksumFlag          string
+		cacheDurationFlag     time.Duration
+		skipUpgradeConfigFlag bool
+		globalCfg             godellauncher.GlobalConfig
 	)
 
 	cmd := &cobra.Command{
@@ -40,21 +42,51 @@ func UpdateTask() godellauncher.Task {
 			if err != nil {
 				return err
 			}
+
+			var godelVersionBeforeUpdate installupdate.Version
+			if !skipUpgradeConfigFlag {
+				versionBeforeUpdateVar, err := installupdate.GodelVersion(projectDir)
+				if err != nil {
+					return errors.Wrapf(err, "failed to determine version before update")
+				}
+				godelVersionBeforeUpdate = versionBeforeUpdateVar
+			}
+
 			if syncFlag {
 				// if sync flag is true, update version to what is specified in gödel.yml
 				pkgSrc, err := installupdate.GodelPropsDistPkgInfo(projectDir)
 				if err != nil {
 					return err
 				}
-				return installupdate.Update(projectDir, pkgSrc, cmd.OutOrStdout())
+				if err := installupdate.Update(projectDir, pkgSrc, cmd.OutOrStdout()); err != nil {
+					return err
+				}
+			} else {
+				if err := installupdate.InstallVersion(projectDir, versionFlag, checksumFlag, cacheDurationFlag, false, cmd.OutOrStdout()); err != nil {
+					return err
+				}
 			}
-			return installupdate.InstallVersion(projectDir, versionFlag, checksumFlag, cacheDurationFlag, false, cmd.OutOrStdout())
+
+			// run "upgrade-config" after upgrade if new version is greater than or equal to previous version.
+			if !skipUpgradeConfigFlag {
+				godelVersionAfterUpdate, err := installupdate.GodelVersion(projectDir)
+				if err != nil {
+					return errors.Wrapf(err, "failed to determine version after update")
+				}
+				if cmp, ok := godelVersionAfterUpdate.CompareTo(godelVersionBeforeUpdate); !ok || cmp >= 0 {
+					if err := installupdate.RunUpgradeConfig(projectDir, cmd.OutOrStdout(), cmd.OutOrStderr()); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
 		},
 	}
 	cmd.Flags().BoolVar(&syncFlag, "sync", false, "use version and checksum specified in godel.properties (if true, all other flags are ignored)")
 	cmd.Flags().StringVar(&versionFlag, "version", "", "version to update (if blank, uses latest version)")
 	cmd.Flags().StringVar(&checksumFlag, "checksum", "", "expected checksum for package")
 	cmd.Flags().DurationVar(&cacheDurationFlag, "cache-duration", time.Hour, "duration for which cache entries should be considered valid")
+	cmd.Flags().BoolVar(&skipUpgradeConfigFlag, "skip-upgrade-config", false, "skips running configuration upgrade tasks after running update")
 
 	return godellauncher.CobraCLITask(cmd, &globalCfg)
 }


### PR DESCRIPTION
Make it so that the "update" task runs "upgrade-config" if needed.
Also make it so that godelinit invokes "upgrade-legacy-config" or
"upgrade-config" as needed.