### PR TITLE
Implement plugin overrides

### DIFF
--- a/framework/artifactresolver/param.go
+++ b/framework/artifactresolver/param.go
@@ -37,5 +37,9 @@ type Locator struct {
 }
 
 func (l Locator) String() string {
-	return fmt.Sprintf("%s:%s:%s", l.Group, l.Product, l.Version)
+	return fmt.Sprintf("%s:%s", l.GroupAndProductString(), l.Version)
+}
+
+func (l Locator) GroupAndProductString() string {
+	return fmt.Sprintf("%s:%s", l.Group, l.Product)
 }

--- a/framework/godel/config/internal/v0/godel.go
+++ b/framework/godel/config/internal/v0/godel.go
@@ -76,6 +76,8 @@ type PluginsConfig struct {
 type SinglePluginConfig struct {
 	// LocatorWithResolverConfig stores the locator and the resolver for the plugin.
 	LocatorWithResolverConfig `yaml:",inline,omitempty"`
+	// Override is used to override a plugin found in the ConfigProvider that has the same locator as this plugin.
+	Override bool `yaml:"override,omitempty"`
 	// Assets stores the locators and resolvers for the assets for this plugin.
 	Assets []LocatorWithResolverConfig `yaml:"assets,omitempty"`
 }

--- a/framework/godel/config/internal/v0/upgradeconfig.go
+++ b/framework/godel/config/internal/v0/upgradeconfig.go
@@ -21,7 +21,7 @@ import (
 
 func UpgradeConfig(cfgBytes []byte) ([]byte, error) {
 	var cfg GodelConfig
-	if err := yaml.UnmarshalStrict(cfgBytes, &cfg); err != nil {
+	if err := yaml.Unmarshal(cfgBytes, &cfg); err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal godel v0 configuration")
 	}
 	return cfgBytes, nil

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -243,3 +243,11 @@ func execCommand(t *testing.T, dir, cmdName string, args ...string) string {
 	require.NoError(t, err, "Command %v failed. Output:\n%v", cmd.Args, string(output))
 	return string(output)
 }
+
+func execCommandExpectError(t *testing.T, dir, cmdName string, args ...string) string {
+	cmd := exec.Command(cmdName, args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err)
+	return string(output)
+}


### PR DESCRIPTION
Add "override" property to plugin configuration and allow it
to be used to override plugins specified in configuration providers.

Fixes #427