### PR TITLE
Feature: add exec task

### DIFF
--- a/framework/builtintasks/exec.go
+++ b/framework/builtintasks/exec.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Palantir Technologies, Inc.
+// Copyright 2019 Palantir Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,22 +15,29 @@
 package builtintasks
 
 import (
-	"github.com/palantir/godel/framework/godel/config"
+	"os"
+	"os/exec"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	"github.com/palantir/godel/framework/godellauncher"
 )
 
-func Tasks(tasksCfgInfo config.TasksConfigInfo) []godellauncher.Task {
-	return []godellauncher.Task{
-		VersionTask(),
-		InstallTask(),
-		UpdateTask(),
-		InfoTask(),
-		ExecTask(),
-		CheckPathTask(),
-		GitHooksTask(),
-		GitHubWikiTask(),
-		IDEATask(),
-		PackagesTask(),
-		TasksConfigTask(tasksCfgInfo),
-	}
+func ExecTask() godellauncher.Task {
+	var globalCfg godellauncher.GlobalConfig
+	return godellauncher.CobraCLITask(&cobra.Command{
+		Use:   "exec",
+		Short: "Executes given shell command using godel",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.Errorf("no command specified")
+			}
+			execCmd := exec.Command(args[0], args[1:]...)
+			execCmd.Stdout = cmd.OutOrStdout()
+			execCmd.Stderr = cmd.OutOrStderr()
+			execCmd.Stdin = os.Stdin
+			return execCmd.Run()
+		},
+	}, &globalCfg)
 }

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"path"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/nmiyake/pkg/dirs"
@@ -180,6 +181,26 @@ products:
 	require.NoError(t, err)
 
 	execCommand(t, testProjectDir, "./godelw", "products")
+}
+
+func TestExec(t *testing.T) {
+	testProjectDir := setUpGodelTestAndDownload(t, testRootDir, godelTGZ, version)
+
+	currGodelYML, err := ioutil.ReadFile(path.Join(testProjectDir, "godel", "config", "godel.yml"))
+	require.NoError(t, err)
+
+	updatedGodelYML := string(currGodelYML) + `
+environment:
+  MY_ENV_VAR: "FOO"
+`
+	err = ioutil.WriteFile(path.Join(testProjectDir, "godel", "config", "godel.yml"), []byte(updatedGodelYML), 0644)
+	require.NoError(t, err)
+
+	out := execCommand(t, testProjectDir, "./godelw", "exec", "env")
+	idx := strings.Index(out, "MY_ENV_VAR=FOO\n")
+
+	// do not print content of "out" on failure, as it may contain sensitive environment variables
+	assert.True(t, idx != -1, "did not find expected environment variable in output")
 }
 
 func TestTest(t *testing.T) {


### PR DESCRIPTION
Add a built-in "exec" task that executes a given shell command
(with the provided flags and arguments) using godel. Useful for
running commands using the same environment variables set by
godel for its tasks.