### PR TITLE
Fix: include quoted output in parse error

### DIFF
--- a/changelog/@unreleased/pr-504.v2.yml
+++ b/changelog/@unreleased/pr-504.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |-
+    Include quoted output in parse error
+
+    If parsing parts fails, output quoted version of input.
+  links:
+  - https://github.com/palantir/godel/pull/504

--- a/framework/builtintasks/installupdate/godelwcmds.go
+++ b/framework/builtintasks/installupdate/godelwcmds.go
@@ -60,7 +60,7 @@ func getGodelVersion(projectDir string) (godelVersion, error) {
 
 	parts := strings.Split(outputString, " ")
 	if len(parts) != 3 {
-		return godelVersion{}, errors.Errorf(`expected output %s to have 3 parts when split by " ", but was %v`, outputString, parts)
+		return godelVersion{}, errors.Errorf(`expected output %q to have 3 parts when split by " ", but was %v`, outputString, parts)
 	}
 	v, err := newGodelVersion(parts[2])
 	if err != nil {


### PR DESCRIPTION
If parsing parts fails, output quoted version of input.