### PR TITLE
Fix: always output newlines after progress

### DIFF
--- a/changelog/@unreleased/pr-505.v2.yml
+++ b/changelog/@unreleased/pr-505.v2.yml
@@ -1,0 +1,13 @@
+type: fix
+fix:
+  description: |-
+    Always output newlines after progress
+
+    Explicitly set the return symbol for progress bars so that
+    returns and newlines are always added, even when not in terminal
+    mode.
+
+    Also changes splitting logic to only split on "\r" and "\n" rather
+    than on all Unicode line break characters.
+  links:
+  - https://github.com/palantir/godel/pull/505

--- a/framework/builtintasks/installupdate/godelwcmds.go
+++ b/framework/builtintasks/installupdate/godelwcmds.go
@@ -70,21 +70,10 @@ func getGodelVersion(projectDir string) (godelVersion, error) {
 }
 
 func getLastLine(in string) (string, error) {
-	outputLines := strings.Split(unicodeLineBreaksToNewlines(strings.TrimSpace(in)), "\n")
+	outputLines := strings.Split(strings.Replace(strings.TrimSpace(in), "\r", "\n", -1), "\n")
 	if len(outputLines) == 0 {
 		return "", errors.Errorf("no elements found when splitting output %q on newlines", in)
 
 	}
 	return outputLines[len(outputLines)-1], nil
-}
-
-func unicodeLineBreaksToNewlines(s string) string {
-	return strings.Map(func(r rune) rune {
-		switch r {
-		case 0x000A, 0x000B, 0x000C, 0x000D, 0x0085, 0x2028, 0x2029:
-			return '\n'
-		default:
-			return r
-		}
-	}, s)
 }

--- a/framework/builtintasks/installupdate/godelwcmds_test.go
+++ b/framework/builtintasks/installupdate/godelwcmds_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Verifies that getLastLine properly splits on unicode line breaks.
+// Verifies that getLastLine properly splits on both \r and \n.
 func TestGetLastLine(t *testing.T) {
 	for i, tc := range []struct {
 		in   string
@@ -38,31 +38,7 @@ second line`,
 			"second line",
 		},
 		{
-			fmt.Sprint("first line", string('\u000A'), "second line"),
-			"second line",
-		},
-		{
-			fmt.Sprint("first line", string('\u000B'), "second line"),
-			"second line",
-		},
-		{
-			fmt.Sprint("first line", string('\u000C'), "second line"),
-			"second line",
-		},
-		{
-			fmt.Sprint("first line", string('\u000D'), "second line"),
-			"second line",
-		},
-		{
-			fmt.Sprint("first line", string('\u0085'), "second line"),
-			"second line",
-		},
-		{
-			fmt.Sprint("first line", string('\u2028'), "second line"),
-			"second line",
-		},
-		{
-			fmt.Sprint("first line", string('\u2029'), "second line"),
+			fmt.Sprint("first line", "\r", "second line"),
 			"second line",
 		},
 	} {

--- a/godelgetter/download.go
+++ b/godelgetter/download.go
@@ -125,6 +125,8 @@ func Download(pkgSrc PkgSrc, dstFilePath string, w io.Writer) (rErr error) {
 func copyWithProgress(w io.Writer, r io.Reader, dataLen int64, stdout io.Writer) error {
 	bar := pb.New64(dataLen)
 	mw := bar.NewProxyWriter(w)
+	// explicitly set so that returns are written even in non-terminal mode
+	bar.Set(pb.ReturnSymbol, "\r")
 	bar.SetMaxWidth(120)
 	bar.SetWriter(stdout)
 	bar.Start()


### PR DESCRIPTION
Explicitly set the return symbol for progress bars so that
returns and newlines are always added, even when not in terminal
mode.

Also changes splitting logic to only split on "\r" and "\n" rather
than on all Unicode line break characters.