### PR TITLE
Remove brew-go image from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,6 @@ executors:
       CGO_ENABLED: 0
     docker:
       - image: palantirtechnologies/go:alpine-go-<< parameters.version >>-t57
-  brew-go:
-    working_directory: /go/src/github.com/palantir/godel
-    docker:
-      - image: palantirtechnologies/go:brew-go-t57
 
 jobs:
   wiki:
@@ -51,7 +47,6 @@ requires_products: &requires_products
   - integration-std
   - integration-alpine-go-curr
   - integration-alpine-go-prev
-  - integration-brew
   - dist
   - pkg-products-verify-test
 
@@ -87,21 +82,6 @@ workflows:
           executor:
             name: alpine-go
             version: 1.14.7
-          <<: *all-tags-filter
-      - godel/test:
-          name: integration-brew
-          tags: integration
-          executor: brew-go
-          cache-steps:
-            - restore_cache:
-                keys:
-                  - godel-linuxbrew-cache-{{ checksum "godelw" }}-{{ checksum "godel/config/godel.yml" }}-v1
-            - run: ./godelw version
-            - save_cache:
-                key: godel-linuxbrew-cache-{{ checksum "godelw" }}-{{ checksum "godel/config/godel.yml" }}-v1
-                paths:
-                  - /home/linuxbrew/.godel
-          build-cache-path: /home/linuxbrew/.cache/go-build
           <<: *all-tags-filter
       - godel/verify:
           name: pkg-products-verify-test

--- a/changelog/@unreleased/pr-525.v2.yml
+++ b/changelog/@unreleased/pr-525.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: Removes brew-go environment in CircleCI from integration tests. Now
+    that most projects use Go modules, GOPATH and GOROOT have much less significance
+    and specifically testing in an environment where go is installed using `brew`
+    is less imoprtant.
+  links:
+  - https://github.com/palantir/godel/pull/525


### PR DESCRIPTION
## Before this PR
brew-go image was historically part of integration tests to ensure that GOROOT/GOPATH issues did not occur when using Go installed by `brew` (as opposed to a standard installation). This was particularly relevant in situations where a project was attempting to be built outside the GOPATH.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Removes brew-go environment in CircleCI from integration tests. Now that most projects use Go modules, GOPATH and GOROOT have much less significance and specifically testing in an environment where go is installed using `brew` is less imoprtant.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

