### PR TITLE
Lock plugin files when getting task information

### DIFF
--- a/changelog/@unreleased/pr-536.v2.yml
+++ b/changelog/@unreleased/pr-536.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixes issue where getting plugin information could fail when multiple instances of godel are performing resolution concurrently. Note that, in order for this fix to work, all of the copies of godel that are running concurrently must have this fix.
+  links:
+  - https://github.com/palantir/godel/pull/536

--- a/framework/pluginapi/plugininfo.go
+++ b/framework/pluginapi/plugininfo.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/palantir/godel/v2/framework/godellauncher"
 	"github.com/pkg/errors"
+	"github.com/rogpeppe/go-internal/lockedfile"
 )
 
 const (
@@ -173,6 +174,16 @@ func (infoImpl pluginInfoImpl) private() {}
 // InfoFromPlugin returns the Info for the plugin at the specified path. Does so by invoking the InfoCommand on the
 // plugin and parsing the output.
 func InfoFromPlugin(pluginPath string) (PluginInfo, error) {
+	// use lockedfile.Open on plugin to ensure that it is not overwritten when called
+	pluginFile, err := lockedfile.Open(pluginPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read plugin file %s", pluginPath)
+	}
+	defer func() {
+		// close file to return lock
+		_ = pluginFile.Close()
+	}()
+
 	cmd := exec.Command(pluginPath, PluginInfoCommandName)
 	bytes, err := cmd.CombinedOutput()
 	if err != nil {

--- a/framework/pluginapi/v2/pluginapi/plugininfo.go
+++ b/framework/pluginapi/v2/pluginapi/plugininfo.go
@@ -23,6 +23,7 @@ import (
 	"github.com/palantir/godel/v2/framework/godellauncher"
 	v1 "github.com/palantir/godel/v2/framework/pluginapi"
 	"github.com/pkg/errors"
+	"github.com/rogpeppe/go-internal/lockedfile"
 )
 
 const (
@@ -259,6 +260,16 @@ func (infoImpl pluginInfoImpl) private() {}
 // InfoFromPlugin returns the Info for the plugin at the specified path. Does so by invoking the InfoCommand on the
 // plugin and parsing the output.
 func InfoFromPlugin(pluginPath string) (PluginInfo, error) {
+	// use lockedfile.Open on plugin to ensure that it is not overwritten when called
+	pluginFile, err := lockedfile.Open(pluginPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read plugin file %s", pluginPath)
+	}
+	defer func() {
+		// close file to return lock
+		_ = pluginFile.Close()
+	}()
+
 	cmd := exec.Command(pluginPath, PluginInfoCommandName)
 	bytes, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Before this PR
Getting task information for plugins can fail when multiple instances of godel are resolving artifacts concurrently

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixes issue where getting plugin information could fail when multiple instances of godel are performing resolution concurrently. Note that, in order for this fix to work, all of the copies of godel that are running concurrently must have this fix.
==COMMIT_MSG==

Makes plugin resolution more resilient to concurrent runs of
godel.

Fixes #535

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
