### PR TITLE
Require plugin resolution to lock godel-resolver.lock file

### DIFF
--- a/changelog/@unreleased/pr-537.v2.yml
+++ b/changelog/@unreleased/pr-537.v2.yml
@@ -1,0 +1,10 @@
+type: fix
+fix:
+  description: |-
+    Fixes issue where godel could fail if multiple instances were performing plugin and/or asset resolution at the same time.
+
+    Introduces a new "godel-resolver.lock" file in the godel plugins
+    directory that must be locked while plugin and asset resolution
+    is performed.
+  links:
+  - https://github.com/palantir/godel/pull/537

--- a/changelog/@unreleased/pr-537.v2.yml
+++ b/changelog/@unreleased/pr-537.v2.yml
@@ -1,7 +1,7 @@
 type: fix
 fix:
   description: |-
-    Fixes issue where godel could fail if multiple instances were performing plugin and/or asset resolution at the same time.
+    Fixes issue where godel could fail if multiple instances were performing plugin and/or asset resolution at the same time. Note that, in order for this fix to work, all of the copies of godel that are running concurrently must have this fix.
 
     Introduces a new "godel-resolver.lock" file in the godel plugins
     directory that must be locked while plugin and asset resolution


### PR DESCRIPTION
## Before this PR
Prior to this PR, attempts were made to fix issues with concurrent resolution of godel files (#533, #535) by locking individual files while they were being downloaded, verified and executed (#534, #535).

However, the previous approaches did not fully work and also suffered from a whack-a-mole problem where we had to ensure that every individual operation that operated on a file that could be resolved had to lock the file. Additionally, that locking mechanism often still led to duplicated work: if process 1 and process 2 both saw that a file did not exist, although process 2 would wait for process 1 to download the file before proceeding, after process 1 released the lock process 2 would then acquire the lock and perform the same download again.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Introduces a new "godel-resolver.lock" file in the godel plugins
directory that must be locked while plugin and asset resolution
is performed. This ensures that multiple instances of godel
resolving plugins and assets concurrently works as expected.
==COMMIT_MSG==

In contrast to the previous approach, this approach is simpler and more comprehensive: because all resolution operations are performed while acquiring a lock on a single file, there's no need to ensure that all of the individual operations lock and unlock. Additionally, if a process does block on the lock, it will generally duplicate less work because it will not proceed until the other process finishes all resolution, which means that any shared files will not be redownloaded. The use of a single lock file for operations like this is also a common practice used by similar tools.

Experimentally, I was able to verify locally that this approach solved the issues that the previous approach did not.

Fixes #533, #535

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
