### PR TITLE
Update godelw to make resilient to concurrent downloads

### DIFF
--- a/changelog/@unreleased/pr-541.v2.yml
+++ b/changelog/@unreleased/pr-541.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixes issue where concurrent invocations of godelw could fail when the godel distribution did not already exist.
+  links:
+  - https://github.com/palantir/godel/pull/541

--- a/resources/wrapper/godelw
+++ b/resources/wrapper/godelw
@@ -198,8 +198,11 @@ if [ ! -f "$CMD" ]; then
     mkdir -p "$GODEL_BASE_DIR/downloads"
 
     # download tgz and verify its contents
-    DOWNLOAD_DST=$GODEL_BASE_DIR/downloads/godel-$VERSION.tgz
+    # Download to unique location that includes PID ($$) and use trap ensure that temporary download file is cleaned up
+    # if script is terminated before the file is moved to its destination.
+    DOWNLOAD_DST=$GODEL_BASE_DIR/downloads/godel-$VERSION-$$.tgz
     download "$DOWNLOAD_URL" "$DOWNLOAD_DST"
+    trap 'rm -rf "$DOWNLOAD_DST"' EXIT
     if [ -n "$DOWNLOAD_CHECKSUM" ]; then
         verify_checksum "$DOWNLOAD_DST" "$DOWNLOAD_CHECKSUM"
     fi
@@ -210,6 +213,9 @@ if [ ! -f "$CMD" ]; then
     trap 'rm -rf "$TMP_DIST_DIR"' EXIT
     tar zxvf "$DOWNLOAD_DST" -C "$TMP_DIST_DIR" >/dev/null 2>&1
     verify_godel_version "$TMP_DIST_DIR" "$VERSION" "$OS"
+
+    # rename downloaded file to remove PID portion
+    mv "$DOWNLOAD_DST" "$GODEL_BASE_DIR/downloads/godel-$VERSION.tgz"
 
     # if destination directory for distribution already exists, remove it
     if [ -d "$GODEL_BASE_DIR/dists/godel-$VERSION" ]; then
@@ -222,6 +228,17 @@ if [ ! -f "$CMD" ]; then
     # move expanded distribution directory to destination location. The location of the unarchived directory is known to
     # be in the same directory tree as the destination, so "mv" should always work.
     mv "$TMP_DIST_DIR/godel-$VERSION" "$GODEL_BASE_DIR/dists/godel-$VERSION"
+
+    # edge case cleanup: if the destination directory "$GODEL_BASE_DIR/dists/godel-$VERSION" was created prior to the
+    # "mv" operation above, then the move operation will move the source directory into the destination directory. In
+    # this case, remove the directory. It should always be safe to remove this directory because if the directory
+    # existed in the distribution and was non-empty, then the move operation would fail (because non-empty directories
+    # cannot be overwritten by mv). All distributions of a given version are also assumed to be identical. The only
+    # instance in which this would not work is if the distribution purposely contained an empty directory that matched
+    # the name "godel-$VERSION", and this is assumed to never be true.
+    if [ -d "$GODEL_BASE_DIR/dists/godel-$VERSION/godel-$VERSION" ]; then
+        rm -rf "$GODEL_BASE_DIR/dists/godel-$VERSION/godel-$VERSION"
+    fi
 fi
 
 verify_checksum "$CMD" "$EXPECTED_CHECKSUM"


### PR DESCRIPTION
Fixes #539

## Before this PR
Concurrent invocations of godelw could fail when distribution did not already exist due to downloads going to the same file location.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixes issue where concurrent invocations of godelw could fail when the godel distribution did not already exist.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

