### PR TITLE
Add GroupParts template function to resolver

### DIFF
--- a/changelog/@unreleased/pr-546.v2.yml
+++ b/changelog/@unreleased/pr-546.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Adds a "GroupParts" template function to the resolver template
+    that returns the dot-delimited parts of the "Group" field of
+    a locator's "Group" field as an array.
+  links:
+  - https://github.com/palantir/godel/pull/546

--- a/framework/artifactresolver/resolver_template.go
+++ b/framework/artifactresolver/resolver_template.go
@@ -62,6 +62,9 @@ func funcMap(locator LocatorParam, osArch osarch.OSArch) template.FuncMap {
 		"GroupPath": func() string {
 			return strings.Replace(locator.Group, ".", "/", -1)
 		},
+		"GroupParts": func() []string {
+			return strings.Split(locator.Group, ".")
+		},
 		"Product": func() string {
 			return locator.Product
 		},

--- a/framework/artifactresolver/resolver_test.go
+++ b/framework/artifactresolver/resolver_test.go
@@ -140,6 +140,22 @@ func TestRenderResolve(t *testing.T) {
 			},
 			"/foo/a/b/c/Product-darwin-amd64-Version",
 		},
+		{
+			"group parts",
+			ts.URL + "/{{index GroupParts 1}}/{{index GroupParts 2}}/{{Product}}-{{OS}}-{{Arch}}-{{Version}}",
+			LocatorParam{
+				Locator: Locator{
+					Group:   "a.b.c",
+					Product: "Product",
+					Version: "Version",
+				},
+			},
+			osarch.OSArch{
+				OS:   "darwin",
+				Arch: "amd64",
+			},
+			"/b/c/Product-darwin-amd64-Version",
+		},
 	} {
 		r, err := NewTemplateResolver(tc.template)
 		require.NoError(t, err, "Case %d: %s", i, tc.name)
@@ -147,6 +163,5 @@ func TestRenderResolve(t *testing.T) {
 		err = r.Resolve(tc.locator, tc.osArch, dstFile, buf)
 		require.NoError(t, err, "Case %d: %s", i, tc.name)
 		assert.Equal(t, tc.want, got, "Case %d: %s", i, tc.name)
-		fmt.Println(buf.String())
 	}
 }


### PR DESCRIPTION
## Before this PR
There is currently no way to extract the different parts of the "Group" field of a locator in a resolver template. We are considering creating a convention where we define the Group to be of the form "com.{GitHubOwner}.{GitHubRepo}" and would like to enable resolver templates to be defined in a manner that access these different parts, but we cannot do so with the set of template functions that are currently defined.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds a "GroupParts" template function to the resolver template
that returns the dot-delimited parts of the "Group" field of
a locator's "Group" field as an array.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

