### PR TITLE
docsgenerator: make docs generator compatible with latest Docker

### DIFF
--- a/docsgenerator/generator/generator.go
+++ b/docsgenerator/generator/generator.go
@@ -156,6 +156,7 @@ func Generate(inputDir, outputDir, baseImage string, params Params, stdout io.Wr
 
 func runDockerBuild(workDir, tag string, suppressDockerOutput bool, stdout io.Writer) (string, error) {
 	cmd := exec.Command("docker", "build", "--no-cache", "-t", tag, ".")
+	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=0")
 	cmd.Dir = workDir
 
 	outputBuf := &bytes.Buffer{}


### PR DESCRIPTION
## Before this PR
The docsgenerator program (used by the `docs/templates/generate.sh` script to programmatically generate the documentation based on templates) fails to run with newer versions of Docker that use BuildKit.

## After this PR
Set the "DOCKER_BUILDKIT" environment variable to "0" when invoking
"docker build" in docsgenerator to keep the output in the legacy
format so that docsgenerator can parse it.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
docsgenerator: fixes issue where docsgenerator would fail when run with new versions of Docker that use BuildKit
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

