### PR TITLE
Remove go environment variable setup in main.go

### DIFF
--- a/changelog/@unreleased/pr-581.v2.yml
+++ b/changelog/@unreleased/pr-581.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    Remove go code that attempts to set GOROOT and GOPATH environment
+    variables on start. Should not be necessary with go modules.
+  links:
+  - https://github.com/palantir/godel/pull/581

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path"
 
-	"github.com/nmiyake/pkg/dirs"
 	"github.com/nmiyake/pkg/errorstringer"
 	"github.com/palantir/godel/v2/framework/builtintasks"
 	"github.com/palantir/godel/v2/framework/godel"
@@ -28,13 +27,9 @@ import (
 	"github.com/palantir/godel/v2/framework/godellauncher"
 	"github.com/palantir/godel/v2/framework/godellauncher/defaulttasks"
 	"github.com/palantir/godel/v2/framework/plugins"
-	"github.com/pkg/errors"
 )
 
 func main() {
-	if err := dirs.SetGoEnvVariables(); err != nil {
-		printErrAndExit(errors.Wrapf(err, "failed to set Go environment variables"), false)
-	}
 	os.Exit(runGodelApp(os.Args))
 }
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove go code that attempts to set GOROOT and GOPATH environment
variables on start. Should not be necessary with go modules.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

