### PR TITLE
Update CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,11 @@ owner-repo: &owner-repo
   owner-repo: palantir/godel
 
 go-version-current: &go-version-current "1.16.2"
-go-version-prev: &go-version-prev "1.15.10"
+# set go-version-prev to 1.16.2 because integration tests require building darwin-arm64
+# binary and support for doing so is only available starting in Go 1.16. This means that
+# tests will not run on Go 1.15 for now. This will be correct once Go 1.17 becomes the
+# current version.
+go-version-prev: &go-version-prev "1.16.2"
 
 executor: &executor
   executor:


### PR DESCRIPTION
Set go-version-prev to same value as go-version-current. Required
for 1.16 in order to support buildling for darwin-arm64 in integration
tests. This means that tests will not be run for the previous version
of Go for the 1.16 release cycle, but we are willing to make this
trade-off.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

