### PR TITLE
Reverse order of computed resolvers list

### DIFF
--- a/changelog/@unreleased/pr-593.v2.yml
+++ b/changelog/@unreleased/pr-593.v2.yml
@@ -1,7 +1,7 @@
 type: improvement
 improvement:
   description: |-
-    If resolvers are specified  for default tasks, they are now used before the default resolver.
+    If resolvers are specified for default tasks, they are now used before the default resolver.
 
     The prior behavior can be maintained by adding the default resolver as the first entry in the resolver list in the config.
   links:

--- a/changelog/@unreleased/pr-593.v2.yml
+++ b/changelog/@unreleased/pr-593.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    If resolvers are specified  for default tasks, they are now used before the default resolver.
+
+    The prior behavior can be maintained by adding the default resolver as the first entry in the resolver list in the config.
+  links:
+    - https://github.com/palantir/godel/pull/593

--- a/framework/godellauncher/defaulttasks/defaulttasks.go
+++ b/framework/godellauncher/defaulttasks/defaulttasks.go
@@ -246,7 +246,7 @@ func PluginsConfig(cfg config.DefaultTasksConfig) (config.PluginsConfig, error) 
 		DefaultResolvers: defaultPluginsConfig.DefaultResolvers,
 	}
 	// append default resolvers provided by the configuration and uniquify
-	pluginsCfg.DefaultResolvers = pluginsinternal.Uniquify(append(pluginsCfg.DefaultResolvers, cfg.DefaultResolvers...))
+	pluginsCfg.DefaultResolvers = pluginsinternal.Uniquify(append(cfg.DefaultResolvers, pluginsCfg.DefaultResolvers...))
 
 	defaultPluginKeys := make(map[string]struct{})
 	for _, currPlugin := range defaultPluginsConfig.Plugins {

--- a/framework/godellauncher/defaulttasks/defaulttasks_test.go
+++ b/framework/godellauncher/defaulttasks/defaulttasks_test.go
@@ -193,8 +193,8 @@ func TestDefaultTasksPluginsConfig(t *testing.T) {
 			"",
 			config.PluginsConfig{
 				DefaultResolvers: []string{
-					defaultResolver,
 					"default/repo/{{GroupPath}}/{{Product}}/{{Version}}/{{Product}}-{{OS}}-{{Arch}}-{{Version}}.tgz",
+					defaultResolver,
 				},
 				Plugins: config.ToSinglePluginConfigs([]config.SinglePluginConfig{
 					{


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Previously the hard-coded default resolver was used first.  This meant that even if resolvers were specified in config, godel would still attempt to reach the hard coded default (github.com).  In environments without internet access this behavior is undesirable.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Now the configured resolvers are checked first and the default is used as a fallback.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
If the configured resolvers do not have most of the plugins/assets this change will cause more resolver misses.  However, these misses will only make the initial resolution slower, no functionality change is expected.  In addition, since plugins are typically cached and read from disk this increase in resolution time should not have significant effect on most workflows.

