### PR TITLE
Make upgrade-config gracefully handle missing configuration

### DIFF
--- a/changelog/@unreleased/pr-619.v2.yml
+++ b/changelog/@unreleased/pr-619.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Changes the behavior of the `upgrade-config` command such that, if
+    the configuration for a plugin does not exist, it is ignored and treated as a
+    success rather than a failure.
+  links:
+  - https://github.com/palantir/godel/pull/619

--- a/framework/builtintasks/upgradeconfig.go
+++ b/framework/builtintasks/upgradeconfig.go
@@ -147,6 +147,10 @@ func upgradeConfigFile(task godellauncher.UpgradeConfigTask, global godellaunche
 	configFile := filepath.Join(configDir, task.ConfigFile)
 	origConfigBytes, err := os.ReadFile(configFile)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// if configuration file does not exist, skip
+			return false, nil, nil
+		}
 		return false, nil, errors.Wrapf(err, "failed to read config file")
 	}
 	upgradedConfigBytes, err := task.Run(origConfigBytes, global, stdout)


### PR DESCRIPTION
## Before this PR
Running `./godelw upgrade-config` fails if a plugin does not have a configuration file, even if the plugin itself runs properly without a configuration file.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Changes the behavior of the `upgrade-config` command such that, if the configuration for a plugin does not exist, it is ignored and treated as a success rather than a failure.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

