### PR TITLE
fix compute_sha256 if openssl3 is on the path

### DIFF
--- a/changelog/@unreleased/pr-630.v2.yml
+++ b/changelog/@unreleased/pr-630.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: fix compute_sha256 in godelw script if openssl3 is on the path
+  links:
+  - https://github.com/palantir/godel/pull/630

--- a/resources/wrapper/godelw
+++ b/resources/wrapper/godelw
@@ -91,7 +91,7 @@ function compute_sha256 {
     local file=$1
     if command -v openssl >/dev/null 2>&1; then
         # print SHA-256 hash using openssl
-        openssl dgst -sha256 "$file" | sed -E 's/SHA256\(.*\)= //'
+        openssl dgst -sha256 "$file" | sed -E 's/SHA(2-)?256\(.*\)= //'
     elif command -v shasum >/dev/null 2>&1; then
         # Darwin systems ship with "shasum" utility
         shasum -a 256 "$file" | sed -E 's/[[:space:]]+.+//'


### PR DESCRIPTION
When the version of openssl on the path is openssl3, the output of `openssl dgst -sha256 <file>` is different.

Older versions of openssl could output "SHA256(...)=..." while openssl3 outputs "SHA2-256(...)=...".

Using `openssl dgst -sha256 -r <file>` might be more simple to use the output (because the output format will match the alternate commands), but I have not tested this on different versions of openssl.

## Before this PR
If openssl3 is on your path, godelw always fails to verify the hash of downloads.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
fix compute_sha256 in godelw script if openssl3 is on the path
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

