### PR TITLE
Fix checksums in godelw generated by openssl

### DIFF
--- a/changelog/@unreleased/pr-695.v2.yml
+++ b/changelog/@unreleased/pr-695.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixes checksums in the godelw file.
+  links:
+  - https://github.com/palantir/godel/pull/695

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -31,7 +31,7 @@ products:
                 local file=$1
                 if command -v openssl >/dev/null 2>&1; then
                     # print SHA-256 hash using openssl
-                    openssl dgst -sha256 "$file" | sed -E 's/SHA256\(.*\)= //'
+                    openssl dgst -sha256 "$file" | sed -E 's/(SHA256|SHA2-256)\(.*\)= //'
                 elif command -v shasum >/dev/null 2>&1; then
                     # Darwin systems ship with "shasum" utility
                     shasum -a 256 "$file" | sed -E 's/[[:space:]]+.+//'


### PR DESCRIPTION
## Before this PR
The `godelw` file in godel 2.71.0 does not work because the checksums in the file are populated incorrectly (and in a manner that causes a compile error for the script).

## After this PR

Updates logic for populating checksums in the godelw file generated using 'openssl' to trim the "SHA2-256" prefix in addition to "SHA2".

Fixes issue where versions of the 'openssl' command that used "SHA2-256" as the name of the hash algorithm for the '-sha256' flag would generate invalid godelw files.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixes checksums in the godelw file.
==COMMIT_MSG==

Fixes #694

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

