### PR TITLE
Update run-godel-publish GitHub Action to run on release

### DIFF
--- a/.github/workflows/publish-godel-artifacts.yml
+++ b/.github/workflows/publish-godel-artifacts.yml
@@ -1,8 +1,8 @@
 name: publish-godel-artifacts
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+**'
+  release:
+    types:
+      - created
 jobs:
   run-godel-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Before this PR
It appears that the behavior of `autorelease-bot` has changed such that, when it creates an autorelease based on a merged PR, it adds the "[skip ci]" directive (see how release 2.72.0 at https://github.com/palantir/godel/commit/03ca0ca8a4bc4298fc4a864dbe9ab19e4ef826e3 has this directive, while release 2.64.0 at https://github.com/palantir/godel/commit/e2ac15753003abf295f79b66d1709984c4752748 does not).

Currently, the GitHub Action logic for publishing this project runs on the "push: tag" event and matches the expected release tag format. However, per https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs, any "push" event workflows are skipped based on this tag.

This makes it such that the GitHub Action no longer runs for this class of autorelease workflows -- it is why the action didn't run for https://github.com/palantir/godel/releases/tag/v2.72.0, and thus didn't produce a release. Timer-based releases still publish properly because they do not include the "skip CI" directive.

## After this PR
Change the GitHub Action logic that runs the publish operation to run on the event that creates releases rather than matching tags on a push event. Ensures that the GitHub Action for releases will be performed even if the release commit has a "[skip ci]" directive. This is also more semantically correct, as it ties the action to the release being created (and should thus theoretically work even if the tag format is changed in the future).

## Possible downsides?
Changes behavior such that if a release is created that doesn't match the previously defined tag format a release will still be performed. Also makes it such that just pushing a version tag will not trigger the publish workflow (a release must specifically be created in GitHub). However, I believe these behavioral changes should be acceptable.

