### PR TITLE
Update CircleCI Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
         type: string
         default: /home/circleci/go/src/github.com/palantir/godel
     docker:
-      - image: cimg/go:1.16-browsers
+      - image: cimg/go:1.18-browsers
     working_directory: << parameters.working_directory >>
 
 jobs:


### PR DESCRIPTION
Update CircleCI Docker base image to match based image used by CircleCI Go templates.
