### PR TITLE
Only write plugin cache file if cachePath is non-empty

### DIFF
--- a/changelog/@unreleased/pr-886.v2.yml
+++ b/changelog/@unreleased/pr-886.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixes issue where the plugin cache would be attempted to be written
+    even if the cache file path was empty.
+  links:
+  - https://github.com/palantir/godel/pull/886

--- a/framework/plugins/plugin.go
+++ b/framework/plugins/plugin.go
@@ -86,13 +86,15 @@ func loadPluginsTasks(pluginsParam godellauncher.PluginsParam, stdout io.Writer,
 			return nil, nil, err
 		}
 
-		// write plugin information to cache file
-		pluginsJSON, err := marshalPluginsInfoJSON(plugins)
-		if err != nil {
-			return nil, nil, errors.Wrapf(err, "failed to marshal plugin information")
-		}
-		if err := writeFileUsingRename(cachePath, pluginsJSON); err != nil {
-			return nil, nil, errors.Wrapf(err, "failed to write plugin information to cache file at %q", cachePath)
+		if cachePath != "" {
+			// write plugin information to cache file
+			pluginsJSON, err := marshalPluginsInfoJSON(plugins)
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "failed to marshal plugin information")
+			}
+			if err := writeFileUsingRename(cachePath, pluginsJSON); err != nil {
+				return nil, nil, errors.Wrapf(err, "failed to write plugin information to cache file at %q", cachePath)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixes issue where the plugin cache would be attempted to be written even if the cache file path was empty.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

