### PR TITLE
Fix: Redirect all godelw diagnostic/error output to stderr

### DIFF
--- a/godelw
+++ b/godelw
@@ -9,6 +9,11 @@ DARWIN_ARM64_CHECKSUM=8d0013277b18aa703e0e9883e0bdcdee8e95af43f210fcfbabb7d0404e
 LINUX_AMD64_CHECKSUM=f5de3aabd2258198f7236d5d15622c2335eacb26d04663353b4e8ee1b06cb1ba
 LINUX_ARM64_CHECKSUM=658d5719ef4370f4081d2c3439726a1b4dbdf0e89439edd452e13999b2699de2
 
+# Prints the provided arguments to stderr.
+function echo_stderr {
+    echo "$@" >&2
+}
+
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {
     local url=$1
@@ -24,13 +29,13 @@ function download {
 
     # if one of wget or curl is not present, exit with error
     if [ "$wget_exists" -ne 0 -a "$curl_exists" -ne 0 ]; then
-        echo "wget or curl must be present to download distribution. Install one of these programs and try again or install the distribution manually."
+        echo_stderr "wget or curl must be present to download distribution. Install one of these programs and try again or install the distribution manually."
         exit 1
     fi
 
     if [ "$wget_exists" -eq 0 ]; then
         # attempt download using wget
-        echo "Downloading $url to $dst..."
+        echo_stderr "Downloading $url to $dst..."
         local progress_opt=""
         if wget --help | grep -q '\--show-progress'; then
             progress_opt="-q --show-progress"
@@ -44,29 +49,29 @@ function download {
             return
         fi
 
-        echo "Download failed using command: wget -O $dst $progress_opt $url"
+        echo_stderr "Download failed using command: wget -O $dst $progress_opt $url"
 
         # curl does not exist, so nothing more to try: exit
         if [ "$curl_exists" -ne 0 ]; then
-            echo "Download failed using wget and curl was not found. Verify that the distribution URL is correct and try again or install the distribution manually."
+            echo_stderr "Download failed using wget and curl was not found. Verify that the distribution URL is correct and try again or install the distribution manually."
             exit 1
         fi
         # curl exists, notify that download will be attempted using curl
-        echo "Attempting download using curl..."
+        echo_stderr "Attempting download using curl..."
     fi
 
     # attempt download using curl
-    echo "Downloading $url to $dst..."
+    echo_stderr "Downloading $url to $dst..."
     set +e
     curl -f -L -o "$dst" "$url"
     rv=$?
     set -e
     if [ "$rv" -ne 0 ]; then
-        echo "Download failed using command: curl -f -L -o $dst $url"
+        echo_stderr "Download failed using command: curl -f -L -o $dst $url"
         if [ "$wget_exists" -eq 0 ]; then
-            echo "Download failed using wget and curl. Verify that the distribution URL is correct and try again or install the distribution manually."
+            echo_stderr "Download failed using wget and curl. Verify that the distribution URL is correct and try again or install the distribution manually."
         else
-            echo "Download failed using curl and wget was not found. Verify that the distribution URL is correct and try again or install the distribution manually."
+            echo_stderr "Download failed using curl and wget was not found. Verify that the distribution URL is correct and try again or install the distribution manually."
         fi
         exit 1
     fi
@@ -79,9 +84,9 @@ function verify_checksum {
     local expected_checksum=$2
     local computed_checksum=$(compute_sha256 $file)
     if [ "$expected_checksum" != "$computed_checksum" ]; then
-        echo "SHA-256 checksum for $file did not match expected value."
-        echo "Expected: $expected_checksum"
-        echo "Actual:   $computed_checksum"
+        echo_stderr "SHA-256 checksum for $file did not match expected value."
+        echo_stderr "Expected: $expected_checksum"
+        echo_stderr "Actual:   $computed_checksum"
         exit 1
     fi
 }
@@ -99,7 +104,7 @@ function compute_sha256 {
         # Most Linux systems ship with sha256sum utility
         sha256sum "$file" | sed -E 's/[[:space:]]+.+//'
     else
-        echo "Could not find program to calculate SHA-256 checksum for file"
+        echo_stderr "Could not find program to calculate SHA-256 checksum for file"
         exit 1
     fi
 }
@@ -133,7 +138,7 @@ function verify_dist_tgz_valid {
 
     # if any expected paths still remain, raise error and exit
     if [[ ${#expected_paths[*]} > 0 ]]; then
-        echo "Required paths were not present in $tgz_path: ${expected_paths[@]}"
+        echo_stderr "Required paths were not present in $tgz_path: ${expected_paths[@]}"
         exit 1
     fi
 }
@@ -150,7 +155,7 @@ function verify_godel_version {
     local version_output=$($base_dir/godel-$version/bin/$os-$arch/godel version)
 
     if [ "$expected_output" != "$version_output" ]; then
-        echo "Version reported by godel executable did not match expected version: expected \"$expected_output\", was \"$version_output\""
+        echo_stderr "Version reported by godel executable did not match expected version: expected \"$expected_output\", was \"$version_output\""
         exit 1
     fi
 }
@@ -186,7 +191,7 @@ case "$(uname)-$(uname -m)" in
         EXPECTED_CHECKSUM=$LINUX_ARM64_CHECKSUM
         ;;
     *)
-        echo "Unsupported operating system-architecture: $(uname)-$(uname -m)"
+        echo_stderr "Unsupported operating system-architecture: $(uname)-$(uname -m)"
         exit 1
         ;;
 esac
@@ -199,12 +204,12 @@ if [ ! -f "$CMD" ]; then
     # get download URL
     PROPERTIES_FILE=$SCRIPT_HOME/godel/config/godel.properties
     if [ ! -f "$PROPERTIES_FILE" ]; then
-        echo "Properties file must exist at $PROPERTIES_FILE"
+        echo_stderr "Properties file must exist at $PROPERTIES_FILE"
         exit 1
     fi
     DOWNLOAD_URL=$(cat "$PROPERTIES_FILE" | sed -E -n "s/^distributionURL=//p")
     if [ -z "$DOWNLOAD_URL" ]; then
-        echo "Value for property \"distributionURL\" was empty in $PROPERTIES_FILE"
+        echo_stderr "Value for property \"distributionURL\" was empty in $PROPERTIES_FILE"
         exit 1
     fi
     DOWNLOAD_CHECKSUM=$(cat "$PROPERTIES_FILE" | sed -E -n "s/^distributionSHA256=//p")


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`godelw` emits echo statements directly to stdout. Some of the output is only run on the self-download path (status, checksums, etc) but others run on every invocation. These all corrupt stdout in cases where users want to capture output.

This pattern is used by a few well known tools/guides:
- google shell style guide: https://google.github.io/styleguide/shellguide.html#stdout-vs-stderr
- nvm.sh: https://github.com/nvm-sh/nvm/blob/b17550a0b9ab691439815dfccc8b73e3a59fa103/nvm.sh#L36-L38
- Maven wrapper (mvnw)

Fixes #400 (partially)

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Redirect all godelw diagnostic/error output to stderr instead of stdout
==COMMIT_MSG==

@nmiyake If #1083 goes in before this change, then I can update the relevant call siteshere, otherwise you will need to update that PR before merging.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

