### PR TITLE
Fix: Plugin/config resolution diagnostics are emitted to stderr instead of stdout

### DIFF
--- a/framework/artifactresolver/resolver.go
+++ b/framework/artifactresolver/resolver.go
@@ -29,14 +29,14 @@ import (
 )
 
 type Resolver interface {
-	Resolve(locator LocatorParam, osArch osarch.OSArch, dst string, stdout io.Writer) error
+	Resolve(locator LocatorParam, osArch osarch.OSArch, dst string, stderr io.Writer) error
 }
 
 // ResolveArtifactTGZ executes ResolveArtifact for an artifact that is known to be a TGZ that contains a single file.
 // The checksum for the artifact is computed by computing the checksum of the file that is in the TGZ archive (rather
 // than the TGZ archive itself).
-func ResolveArtifactTGZ(locatorWithResolver LocatorWithResolverParam, defaultResolvers []Resolver, osArch osarch.OSArch, dst string, stdout io.Writer) error {
-	return ResolveArtifact(locatorWithResolver, defaultResolvers, osArch, dst, pluginTGZFileContentHash, stdout)
+func ResolveArtifactTGZ(locatorWithResolver LocatorWithResolverParam, defaultResolvers []Resolver, osArch osarch.OSArch, dst string, stderr io.Writer) error {
+	return ResolveArtifact(locatorWithResolver, defaultResolvers, osArch, dst, pluginTGZFileContentHash, stderr)
 }
 
 type PathChecksummer func(in string) (string, error)
@@ -49,7 +49,7 @@ type PathChecksummer func(in string) (string, error)
 // resolvers or if a checksum was provided and did not match. Note that, if the function resolves an artifact to the
 // destination, the artifact will not be removed even if the function returns an error (for example, due to checksums
 // not matching).
-func ResolveArtifact(locatorWithResolver LocatorWithResolverParam, defaultResolvers []Resolver, osArch osarch.OSArch, dst string, checksummer PathChecksummer, stdout io.Writer) error {
+func ResolveArtifact(locatorWithResolver LocatorWithResolverParam, defaultResolvers []Resolver, osArch osarch.OSArch, dst string, checksummer PathChecksummer, stderr io.Writer) error {
 	const errIndentSpaces = 4
 
 	resolversToUse := defaultResolvers
@@ -60,7 +60,7 @@ func ResolveArtifact(locatorWithResolver LocatorWithResolverParam, defaultResolv
 	success := false
 	var errs []string
 	for _, resolver := range resolversToUse {
-		if err := resolver.Resolve(locatorWithResolver.LocatorWithChecksums, osArch, dst, stdout); err != nil {
+		if err := resolver.Resolve(locatorWithResolver.LocatorWithChecksums, osArch, dst, stderr); err != nil {
 			errs = append(errs, err.Error())
 			continue
 		}

--- a/framework/artifactresolver/resolver_template.go
+++ b/framework/artifactresolver/resolver_template.go
@@ -41,14 +41,14 @@ type goTemplateResolver struct {
 	tmplSrc string
 }
 
-func (r goTemplateResolver) Resolve(locator LocatorParam, osArch osarch.OSArch, dst string, stdout io.Writer) error {
+func (r goTemplateResolver) Resolve(locator LocatorParam, osArch osarch.OSArch, dst string, stderr io.Writer) error {
 	buf := &bytes.Buffer{}
 	if err := r.tmpl.Funcs(funcMap(locator, osArch)).Execute(buf, nil); err != nil {
 		return errors.Wrapf(err, "failed to execute template %q", r.tmplSrc)
 	}
 	srcURL := buf.String()
 
-	if err := godelgetter.Download(godelgetter.NewPkgSrc(srcURL, ""), dst, stdout); err != nil {
+	if err := godelgetter.Download(godelgetter.NewPkgSrc(srcURL, ""), dst, stderr); err != nil {
 		return errors.Wrapf(err, "failed to resolve artifact at %s", srcURL)
 	}
 	return nil

--- a/framework/internal/pluginsinternal/plugins.go
+++ b/framework/internal/pluginsinternal/plugins.go
@@ -32,7 +32,7 @@ const (
 	IndentSpaces = 4
 )
 
-func ResolveAssets(assetsDir, downloadsDir string, assetParams []artifactresolver.LocatorWithResolverParam, osArch osarch.OSArch, defaultResolvers []artifactresolver.Resolver, stdout io.Writer) ([]artifactresolver.Locator, error) {
+func ResolveAssets(assetsDir, downloadsDir string, assetParams []artifactresolver.LocatorWithResolverParam, osArch osarch.OSArch, defaultResolvers []artifactresolver.Resolver, stderr io.Writer) ([]artifactresolver.Locator, error) {
 	if len(assetParams) == 0 {
 		return nil, nil
 	}
@@ -47,7 +47,7 @@ func ResolveAssets(assetsDir, downloadsDir string, assetParams []artifactresolve
 			downloadsDir,
 			defaultResolvers,
 			osArch,
-			stdout,
+			stderr,
 		)
 		if !ok {
 			continue
@@ -80,14 +80,14 @@ func ResolveAndVerify(
 	dstBaseDir, downloadsDir string,
 	defaultResolvers []artifactresolver.Resolver,
 	osArch osarch.OSArch,
-	stdout io.Writer) (currLocator artifactresolver.Locator, ok bool) {
+	stderr io.Writer) (currLocator artifactresolver.Locator, ok bool) {
 
 	currLocator = currArtifact.LocatorWithChecksums.Locator
 	currDstPath := filepath.Join(dstBaseDir, pathsinternal.PluginFileName(currLocator))
 
 	if _, err := os.Stat(currDstPath); os.IsNotExist(err) {
 		tgzDstPath := filepath.Join(downloadsDir, pathsinternal.PluginFileName(currLocator)+".tgz")
-		if err := artifactresolver.ResolveArtifactTGZ(currArtifact, defaultResolvers, osArch, tgzDstPath, stdout); err != nil {
+		if err := artifactresolver.ResolveArtifactTGZ(currArtifact, defaultResolvers, osArch, tgzDstPath, stderr); err != nil {
 			artifactErrors[currLocator] = err
 			return currLocator, false
 		}

--- a/framework/plugins/configprovider.go
+++ b/framework/plugins/configprovider.go
@@ -41,14 +41,14 @@ import (
 //   - Unmarshals all of the resolved configurations into godellauncher.TasksConfig structs.
 //
 // Returns all of the unmarshaled configurations.
-func LoadProvidedConfigurations(taskConfigProvidersParam godellauncher.TasksConfigProvidersParam, stdout io.Writer) ([]config.TasksConfig, error) {
+func LoadProvidedConfigurations(taskConfigProvidersParam godellauncher.TasksConfigProvidersParam, stderr io.Writer) ([]config.TasksConfig, error) {
 	godelHomeSpecDir, err := layout.GodelHomeSpecDir(specdir.Create)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create gödel home directory")
 	}
 	configsDir := godelHomeSpecDir.Path(layout.ConfigsDir)
 	downloadsDir := godelHomeSpecDir.Path(layout.DownloadsDir)
-	return resolveConfigProviders(configsDir, downloadsDir, taskConfigProvidersParam, stdout)
+	return resolveConfigProviders(configsDir, downloadsDir, taskConfigProvidersParam, stderr)
 }
 
 // resolveConfigProviders resolves all of the configurations provided by the specified parameters. Returns a slice that
@@ -69,7 +69,7 @@ func LoadProvidedConfigurations(taskConfigProvidersParam godellauncher.TasksConf
 //   - If the unmarshal fails, return an error
 //   - If the TaskConfig contains a plugin configuration that specifies an "override" parameter, return an error
 //     (configuration providers are not allowed to set overrides)
-func resolveConfigProviders(configsDir, downloadsDir string, taskConfigProvidersParam godellauncher.TasksConfigProvidersParam, stdout io.Writer) ([]config.TasksConfig, error) {
+func resolveConfigProviders(configsDir, downloadsDir string, taskConfigProvidersParam godellauncher.TasksConfigProvidersParam, stderr io.Writer) ([]config.TasksConfig, error) {
 	var configs []config.TasksConfig
 	providerErrors := make(map[artifactresolver.Locator]error)
 	for _, currProvider := range taskConfigProvidersParam.ConfigProviders {
@@ -79,7 +79,7 @@ func resolveConfigProviders(configsDir, downloadsDir string, taskConfigProviders
 			configsDir,
 			downloadsDir,
 			taskConfigProvidersParam.DefaultResolvers,
-			stdout,
+			stderr,
 		)
 		if !ok {
 			continue
@@ -129,14 +129,14 @@ func resolveAndVerifyConfigProvider(
 	artifactErrors map[artifactresolver.Locator]error,
 	dstBaseDir, downloadsDir string,
 	defaultResolvers []artifactresolver.Resolver,
-	stdout io.Writer) (currLocator artifactresolver.Locator, ok bool) {
+	stderr io.Writer) (currLocator artifactresolver.Locator, ok bool) {
 
 	currLocator = currArtifact.LocatorWithChecksums.Locator
 	currDstPath := filepath.Join(dstBaseDir, pathsinternal.ConfigProviderFileName(currLocator))
 
 	if _, err := os.Stat(currDstPath); os.IsNotExist(err) {
 		downloadDstPath := filepath.Join(downloadsDir, pathsinternal.ConfigProviderFileName(currLocator))
-		if err := artifactresolver.ResolveArtifact(currArtifact, defaultResolvers, osarch.Current(), downloadDstPath, artifactresolver.SHA256ChecksumFile, stdout); err != nil {
+		if err := artifactresolver.ResolveArtifact(currArtifact, defaultResolvers, osarch.Current(), downloadDstPath, artifactresolver.SHA256ChecksumFile, stderr); err != nil {
 			artifactErrors[currLocator] = err
 			return currLocator, false
 		}

--- a/framework/plugins/plugin.go
+++ b/framework/plugins/plugin.go
@@ -47,8 +47,8 @@ type pluginInfoWithAssets struct {
 //   - Creates runnable godellauncher.Task tasks for the plugins.
 //
 // Returns the tasks provided by the plugins in the provided parameters.
-func LoadPluginsTasks(pluginsParam godellauncher.PluginsParam, stdout io.Writer) ([]godellauncher.Task, []godellauncher.UpgradeConfigTask, error) {
-	return loadPluginsTasks(pluginsParam, stdout, "")
+func LoadPluginsTasks(pluginsParam godellauncher.PluginsParam, stderr io.Writer) ([]godellauncher.Task, []godellauncher.UpgradeConfigTask, error) {
+	return loadPluginsTasks(pluginsParam, stderr, "")
 }
 
 // loadPluginsTasks is a helper function that loads the tasks defined by the plugins in the specified parameters and
@@ -58,7 +58,7 @@ func LoadPluginsTasks(pluginsParam godellauncher.PluginsParam, stdout io.Writer)
 // map[artifactresolver.Locator]pluginInfoWithAssets. If the cache file exists, it is read and used to load the plugin
 // information. If the cache file does not exist, the work to resolve the plugins and verify their validity is performed
 // and then the resulting plugin information is written to the cache file.
-func loadPluginsTasks(pluginsParam godellauncher.PluginsParam, stdout io.Writer, cachePath string) ([]godellauncher.Task, []godellauncher.UpgradeConfigTask, error) {
+func loadPluginsTasks(pluginsParam godellauncher.PluginsParam, stderr io.Writer, cachePath string) ([]godellauncher.Task, []godellauncher.UpgradeConfigTask, error) {
 	pluginsDir, assetsDir, downloadsDir, err := pathsinternal.ResourceDirs()
 	if err != nil {
 		return nil, nil, err
@@ -78,7 +78,7 @@ func loadPluginsTasks(pluginsParam godellauncher.PluginsParam, stdout io.Writer,
 	}
 
 	if plugins == nil {
-		plugins, err = resolvePlugins(pluginsDir, assetsDir, downloadsDir, osarch.Current(), pluginsParam, stdout)
+		plugins, err = resolvePlugins(pluginsDir, assetsDir, downloadsDir, osarch.Current(), pluginsParam, stderr)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -147,7 +147,7 @@ func loadPluginsTasks(pluginsParam godellauncher.PluginsParam, stdout io.Writer,
 //     as the plugin information
 //   - If the plugin specifies assets, resolve all of the assets
 //   - Asset resolution uses a process that is analogous to plugin resolution, but performs it in the assets directory
-func resolvePlugins(pluginsDir, assetsDir, downloadsDir string, osArch osarch.OSArch, pluginsParam godellauncher.PluginsParam, stdout io.Writer) (map[artifactresolver.Locator]pluginInfoWithAssets, error) {
+func resolvePlugins(pluginsDir, assetsDir, downloadsDir string, osArch osarch.OSArch, pluginsParam godellauncher.PluginsParam, stderr io.Writer) (map[artifactresolver.Locator]pluginInfoWithAssets, error) {
 	// lock global resolver file while performing resolution
 	pluginResolverLockFilePath := filepath.Join(pluginsDir, "godel-resolver.lock")
 	pluginResolverLock := lockedfile.MutexAt(pluginResolverLockFilePath)
@@ -167,7 +167,7 @@ func resolvePlugins(pluginsDir, assetsDir, downloadsDir string, osArch osarch.OS
 			downloadsDir,
 			pluginsParam.DefaultResolvers,
 			osArch,
-			stdout,
+			stderr,
 		)
 		if !ok {
 			continue
@@ -179,7 +179,7 @@ func resolvePlugins(pluginsDir, assetsDir, downloadsDir string, osArch osarch.OS
 		}
 
 		// plugin has been successfully resolved: resolve assets for plugin
-		assetInfoMap, err := pluginsinternal.ResolveAssets(assetsDir, downloadsDir, currPlugin.Assets, osArch, pluginsParam.DefaultResolvers, stdout)
+		assetInfoMap, err := pluginsinternal.ResolveAssets(assetsDir, downloadsDir, currPlugin.Assets, osArch, pluginsParam.DefaultResolvers, stderr)
 		if err != nil {
 			pluginErrors[currPluginLocator] = errors.Wrapf(err, "failed to get asset(s) for plugin %+v", currPluginLocator)
 			continue

--- a/framework/plugins/plugin_cache.go
+++ b/framework/plugins/plugin_cache.go
@@ -161,7 +161,7 @@ func (p *pluginInfoWithAssets) UnmarshalJSON(data []byte) error {
 // stable (it has not changed in over 9 years), it is unlikely to be an issue (and in such a circumstance, changing the
 // naming scheme of the cache to add some kind of schema prefix or suffix or as a parent directory should be a
 // sufficient solution).
-func LoadPluginsTasksWithCache(pluginsConfig config.PluginsConfig, pluginsParam godellauncher.PluginsParam, stdout io.Writer) ([]godellauncher.Task, []godellauncher.UpgradeConfigTask, error) {
+func LoadPluginsTasksWithCache(pluginsConfig config.PluginsConfig, pluginsParam godellauncher.PluginsParam, stderr io.Writer) ([]godellauncher.Task, []godellauncher.UpgradeConfigTask, error) {
 	configBytes, err := json.Marshal(pluginsConfig)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to marshal plugins config as JSON")
@@ -170,7 +170,7 @@ func LoadPluginsTasksWithCache(pluginsConfig config.PluginsConfig, pluginsParam 
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to create plugins config cache file path")
 	}
-	return loadPluginsTasks(pluginsParam, stdout, pluginsConfigCachePath)
+	return loadPluginsTasks(pluginsParam, stderr, pluginsConfigCachePath)
 }
 
 // Returns the path to the plugins-config cache file for the provided data. The path to the directory for the file is

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func runGodelApp(osArgs []string) int {
 		if err != nil {
 			printErrAndExit(err, global.Debug)
 		}
-		providedConfigs, err := plugins.LoadProvidedConfigurations(configProvidersParam, os.Stdout)
+		providedConfigs, err := plugins.LoadProvidedConfigurations(configProvidersParam, os.Stderr)
 		if err != nil {
 			printErrAndExit(err, global.Debug)
 		}
@@ -89,7 +89,7 @@ func runGodelApp(osArgs []string) int {
 		var defaultUpgradeConfigTasks, pluginUpgradeConfigTasks []godellauncher.UpgradeConfigTask
 
 		tasksCfgInfo.DefaultTasksPluginsConfig = defaultTasksCfg
-		defaultTasks, defaultUpgradeConfigTasks, err = plugins.LoadPluginsTasksWithCache(defaultTasksCfg, defaultTasksParam, os.Stdout)
+		defaultTasks, defaultUpgradeConfigTasks, err = plugins.LoadPluginsTasksWithCache(defaultTasksCfg, defaultTasksParam, os.Stderr)
 		if err != nil {
 			printErrAndExit(err, global.Debug)
 		}
@@ -100,7 +100,7 @@ func runGodelApp(osArgs []string) int {
 		if err != nil {
 			printErrAndExit(err, global.Debug)
 		}
-		pluginTasks, pluginUpgradeConfigTasks, err = plugins.LoadPluginsTasksWithCache(pluginsCfg, pluginsParam, os.Stdout)
+		pluginTasks, pluginUpgradeConfigTasks, err = plugins.LoadPluginsTasksWithCache(pluginsCfg, pluginsParam, os.Stderr)
 		if err != nil {
 			printErrAndExit(err, global.Debug)
 		}


### PR DESCRIPTION
## Before this PR
`os.Stdout` was passed into the plugin loader and when a plugin/asset is not cached, resolving/downloading the plugin would emit `Getting package from ...` and a progress bar into stdout. As a result, stdout would be corrupted and users could not capture the output directly (see #400).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Plugin/config resolution diagnostics are emitted to stderr instead of stdout
==COMMIT_MSG==

I also renamed the function arguments since they were hardcoded as `stdout` which could be misleading now that we pass `os.Stderr`.  I debated on adding an `IOStreams` struct type (similar to what `gh` and `docker-cli` does today), that contains stdout and stderr, but this was overly engineered since only one of the streams would ever be used.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

