### PR TITLE
Improvement: Separate cobra stdout/stderr and prefer ErrOrStderr

### DIFF
--- a/framework/builtintasks/exec.go
+++ b/framework/builtintasks/exec.go
@@ -34,7 +34,7 @@ func ExecTask() godellauncher.Task {
 			}
 			execCmd := exec.Command(args[0], args[1:]...)
 			execCmd.Stdout = cmd.OutOrStdout()
-			execCmd.Stderr = cmd.OutOrStderr()
+			execCmd.Stderr = cmd.ErrOrStderr()
 			execCmd.Stdin = os.Stdin
 			return execCmd.Run()
 		},

--- a/framework/builtintasks/install.go
+++ b/framework/builtintasks/install.go
@@ -44,10 +44,10 @@ func InstallTask() godellauncher.Task {
 				projectDir,
 				skipUpgradeConfigFlagVal,
 				func() error {
-					return installupdate.NewInstall(projectDir, godelgetter.NewPkgSrc(args[0], checksumFlagVal), cmd.OutOrStdout())
+					return installupdate.NewInstall(projectDir, godelgetter.NewPkgSrc(args[0], checksumFlagVal), cmd.ErrOrStderr())
 				},
 				cmd.OutOrStdout(),
-				cmd.OutOrStderr(),
+				cmd.ErrOrStderr(),
 			)
 		},
 	}

--- a/framework/builtintasks/installupdate/install.go
+++ b/framework/builtintasks/installupdate/install.go
@@ -43,7 +43,7 @@ import (
 //
 // Locks on a file in the Godel Home "downloads" directory with a file name derived based on the provided PkgSrc to
 // ensure that this operation does not run concurrently for the same package.
-func install(src godelgetter.PkgSrc, stdout io.Writer) (string, error) {
+func install(src godelgetter.PkgSrc, stderr io.Writer) (string, error) {
 	godelHomeSpecDir, err := layout.GodelHomeSpecDir(specdir.Create)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create SpecDir for gödel home")
@@ -60,7 +60,7 @@ func install(src godelgetter.PkgSrc, stdout io.Writer) (string, error) {
 	}
 	defer unlockFn()
 
-	tgzFilePath, err := godelgetter.DownloadIntoDirectory(src, downloadsDir, stdout)
+	tgzFilePath, err := godelgetter.DownloadIntoDirectory(src, downloadsDir, stderr)
 	if err != nil {
 		return "", err
 	}

--- a/framework/builtintasks/installupdate/update.go
+++ b/framework/builtintasks/installupdate/update.go
@@ -37,11 +37,11 @@ import (
 // installation of gödel in the path, it is overwritten by the new file. However, changes in the "var" directory are
 // purely additive -- files that have been added in this directory in the new distribution will be added, but existing
 // files will not be modified or removed.
-func NewInstall(dstDirPath string, srcPkg godelgetter.PkgSrc, stdout io.Writer) error {
+func NewInstall(dstDirPath string, srcPkg godelgetter.PkgSrc, stderr io.Writer) error {
 	if err := layout.VerifyDirExists(dstDirPath); err != nil {
 		return errors.Wrapf(err, "path %s does not specify an existing directory", dstDirPath)
 	}
-	if err := update(dstDirPath, srcPkg, true, stdout); err != nil {
+	if err := update(dstDirPath, srcPkg, true, stderr); err != nil {
 		return errors.Wrapf(err, "failed to install from %s into %s", srcPkg.Path(), dstDirPath)
 	}
 	return nil
@@ -52,8 +52,8 @@ func NewInstall(dstDirPath string, srcPkg godelgetter.PkgSrc, stdout io.Writer) 
 // files provided by the package that was downloaded. However, changes in the "godel" directory are purely additive --
 // files that have been added in this directory in the new distribution will be added, but existing files will not be
 // modified or removed.
-func Update(projectDirPath string, srcPkg godelgetter.PkgSrc, stdout io.Writer) error {
-	if err := update(projectDirPath, srcPkg, false, stdout); err != nil {
+func Update(projectDirPath string, srcPkg godelgetter.PkgSrc, stderr io.Writer) error {
+	if err := update(projectDirPath, srcPkg, false, stderr); err != nil {
 		return errors.Wrapf(err, "update failed")
 	}
 	return nil
@@ -61,7 +61,7 @@ func Update(projectDirPath string, srcPkg godelgetter.PkgSrc, stdout io.Writer) 
 
 // InstallVersion installs the specified version of gödel in the provided project directory. If targetVersion is the
 // empty string, the latest version is determined and used.
-func InstallVersion(projectDir, targetVersion, wantChecksum string, cacheValidDuration time.Duration, newInstall bool, stdout io.Writer) error {
+func InstallVersion(projectDir, targetVersion, wantChecksum string, cacheValidDuration time.Duration, newInstall bool, stderr io.Writer) error {
 	if targetVersion == "" {
 		version, err := latestGodelVersion(cacheValidDuration)
 		if err != nil {
@@ -80,7 +80,7 @@ func InstallVersion(projectDir, targetVersion, wantChecksum string, cacheValidDu
 	} else {
 		installFn = Update
 	}
-	return installFn(projectDir, pkgSrc, stdout)
+	return installFn(projectDir, pkgSrc, stderr)
 }
 
 // pkgSrcForVersion returns a package source for the provided version. If the distribution for the provided version has
@@ -250,7 +250,7 @@ func GodelPropsDistPkgInfo(projectDir string) (godelgetter.PkgSrc, error) {
 	return godelgetter.NewPkgSrc(url, checksum), nil
 }
 
-func update(wrapperScriptDir string, pkg godelgetter.PkgSrc, newInstall bool, stdout io.Writer) error {
+func update(wrapperScriptDir string, pkg godelgetter.PkgSrc, newInstall bool, stderr io.Writer) error {
 	mode := specdir.Validate
 	if newInstall {
 		mode = specdir.SpecOnly
@@ -260,7 +260,7 @@ func update(wrapperScriptDir string, pkg godelgetter.PkgSrc, newInstall bool, st
 		return errors.Wrapf(err, "%s is not a valid wrapper directory", wrapperScriptDir)
 	}
 
-	version, err := install(pkg, stdout)
+	version, err := install(pkg, stderr)
 	if err != nil {
 		return err
 	}

--- a/framework/builtintasks/update.go
+++ b/framework/builtintasks/update.go
@@ -48,11 +48,11 @@ func UpdateTask() godellauncher.Task {
 					if err != nil {
 						return err
 					}
-					if err := installupdate.Update(projectDir, pkgSrc, cmd.OutOrStdout()); err != nil {
+					if err := installupdate.Update(projectDir, pkgSrc, cmd.ErrOrStderr()); err != nil {
 						return err
 					}
 				} else {
-					if err := installupdate.InstallVersion(projectDir, versionFlagVal, checksumFlagVal, cacheDurationFlagVal, false, cmd.OutOrStdout()); err != nil {
+					if err := installupdate.InstallVersion(projectDir, versionFlagVal, checksumFlagVal, cacheDurationFlagVal, false, cmd.ErrOrStderr()); err != nil {
 						return err
 					}
 				}
@@ -63,7 +63,7 @@ func UpdateTask() godellauncher.Task {
 				skipUpgradeConfigFlagVal,
 				action,
 				cmd.OutOrStdout(),
-				cmd.OutOrStderr(),
+				cmd.ErrOrStderr(),
 			)
 		},
 	}

--- a/framework/godellauncher/cobraclitask.go
+++ b/framework/godellauncher/cobraclitask.go
@@ -42,7 +42,8 @@ func CobraCLITask(cmd *cobra.Command, globalConfigPtr *GlobalConfig) Task {
 			if globalConfigPtr != nil {
 				*globalConfigPtr = global
 			}
-			rootCmd.SetOutput(stdout)
+			rootCmd.SetOut(stdout)
+			rootCmd.SetErr(os.Stderr)
 			args := []string{global.Executable}
 			args = append(args, global.Task)
 			args = append(args, global.TaskArgs...)

--- a/godelinit/cmd/root.go
+++ b/godelinit/cmd/root.go
@@ -61,11 +61,11 @@ to the project. If a specific version of godel is desired, it can be specified u
 		var runFn func() error
 		if localFlagVal != "" {
 			runFn = func() error {
-				return installupdate.NewInstall(projectDir, godelgetter.NewPkgSrc(localFlagVal, checksumFlagVal), cmd.OutOrStdout())
+				return installupdate.NewInstall(projectDir, godelgetter.NewPkgSrc(localFlagVal, checksumFlagVal), cmd.ErrOrStderr())
 			}
 		} else {
 			runFn = func() error {
-				return installupdate.InstallVersion(projectDir, versionFlagVal, checksumFlagVal, cacheDurationFlagVal, true, cmd.OutOrStdout())
+				return installupdate.InstallVersion(projectDir, versionFlagVal, checksumFlagVal, cacheDurationFlagVal, true, cmd.ErrOrStderr())
 			}
 		}
 		return installupdate.RunActionAndUpgradeConfig(
@@ -73,7 +73,7 @@ to the project. If a specific version of godel is desired, it can be specified u
 			skipUpgradeConfigFlagVal,
 			runFn,
 			cmd.OutOrStdout(),
-			cmd.OutOrStderr(),
+			cmd.ErrOrStderr(),
 		)
 	},
 }


### PR DESCRIPTION
## Before this PR
Cobra's `SetOutput` sets the outWriter and errWriter to the same value and is deprecated in favor of `SetOut` and `SetErr`. We used `SetOutput(stdout)` which meant errWriter would be written to stdout as well. Similarly, `cmd.OutOrStderr` returns the outWriter if available and falls back to stderr, whereas `cmd.ErrOrStderr` returns the errWriter and falls back to stderr.

The last change to fix #400 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Separate cobra stdout/stderr and prefer ErrOrStderr for diagnostics output
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

