### PR TITLE
Publish on tag push

### DIFF
--- a/.github/workflows/publish-godel-artifacts.yml
+++ b/.github/workflows/publish-godel-artifacts.yml
@@ -4,9 +4,9 @@
 
 name: publish-godel-artifacts
 on:
-  release:
-    types:
-      - created
+  push:
+    tags:
+      - 'v[0-9]*'
 
 jobs:
   run-godel-publish:

--- a/.palantir/autorelease.yml
+++ b/.palantir/autorelease.yml
@@ -1,5 +1,11 @@
 version: 3
 
+options:
+  # Remove '[skip ci]' from Autorelease commit messages. The publish-godel-artifacts workflow triggers on the
+  # release tag push, and GitHub Actions honors '[skip ci]' on the tagged commit, so leaving it in would skip the
+  # publish run.
+  disable_skip_ci: true
+
 # Create the GitHub release as a draft so that the publish-godel-artifacts workflow
 # can upload the dist artifacts and then finalize (un-draft) the release.
 github_releases:

--- a/godel/config/godel.yml
+++ b/godel/config/godel.yml
@@ -1,3 +1,16 @@
+default-tasks:
+  tasks:
+    # Override the built-in dist-plugin with 1.105.0, which includes the GitHub publisher change that reuses
+    # an existing draft release created by Autorelease. Remove this override once a released version of godel
+    # bundles dist-plugin >= 1.105.0.
+    com.palantir.distgo:dist-plugin:
+      locator:
+        id: com.palantir.distgo:dist-plugin:1.105.0
+        checksums:
+          darwin-amd64: 8bedb7e5f658ca68f73e409573ed09a697ec8f16b854bcae7c3aeb67624f0570
+          darwin-arm64: 2f6d397ec51013b107e97979a024208fb2ee56ecfbbd6afb84470e92e6adb227
+          linux-amd64: ac3613e6ea83ce1d5a6d4028ddbbe10fc41c10c3650ac2f2dad918515fffed3d
+          linux-arm64: 33dcaa1d99c8632c2ddd23abd0adcc4b98f597339f682eba9a8bcc066e199d69
 plugins:
   resolvers:
     - https://github.com/{{index GroupParts 1}}/{{index GroupParts 2}}/releases/download/v{{Version}}/{{Product}}-{{Version}}-{{OS}}-{{Arch}}.tgz


### PR DESCRIPTION
## Before this PR
#1094 updated distgo and the autorelease config to allow autorelease to create a draft release and distgo GH publisher to upload assets and finalize the release. However, the `publish-godel-artifacts` workflow only runs on a release being created which doesn't trigger for draft releases, so we need to switch to a tag push which autorelease still does for a draft release.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Publish on tag push
==COMMIT_MSG==

In order to get a release cut I am going to manually push a tag to force the github publisher to create the release. If we used autorelease then it would create the tag and draft release but distgo has not been updated in the version of godel used in godel so another draft release would be created again.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

